### PR TITLE
test: integration tests for bridge lifecycle, cancellation, and debugger (#66, #67, #68)

### DIFF
--- a/packages/core/tests/test_bridge_lifecycle.py
+++ b/packages/core/tests/test_bridge_lifecycle.py
@@ -170,7 +170,9 @@ class TestBridgeEventEmission:
     def test_paused_event_includes_node_id(self):
         from rpaforge.bridge.events import ProcessPausedEvent
 
-        event = ProcessPausedEvent(file="main.py", line=10, node_id="node-42", reason="breakpoint")
+        event = ProcessPausedEvent(
+            file="main.py", line=10, node_id="node-42", reason="breakpoint"
+        )
         data = event.to_dict()
 
         assert data["type"] == EventType.PROCESS_PAUSED.value

--- a/packages/core/tests/test_bridge_lifecycle.py
+++ b/packages/core/tests/test_bridge_lifecycle.py
@@ -1,0 +1,186 @@
+"""Integration tests for bridge lifecycle — ready signal, disconnect, shutdown cleanup."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from rpaforge.bridge.events import EventType
+
+
+class TestBridgeHandlersInit:
+    """BridgeHandlers initializes in a ready/idle state."""
+
+    @pytest.fixture
+    def handlers(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        engine = StudioEngine()
+        return BridgeHandlers(engine)
+
+    def test_ping_reports_idle_on_startup(self, handlers):
+        result = handlers._handle_ping({})
+
+        assert result["pong"] is True
+        assert result["status"] == "idle"
+        assert result["isRunning"] is False
+        assert result["isPaused"] is False
+
+    def test_no_active_process_on_init(self, handlers):
+        assert handlers._process_id is None
+        assert handlers._process_task is None
+        assert handlers._cancel_requested is False
+        assert handlers._paused is False
+
+    def test_stop_process_when_idle_returns_no_process(self, handlers):
+        result = handlers._handle_stop_process({})
+
+        assert result["status"] == "no_process"
+
+    def test_pause_process_when_idle_returns_not_running(self, handlers):
+        result = handlers._handle_pause_process({})
+
+        assert result["status"] == "not_running"
+
+    def test_resume_process_when_idle_returns_not_paused(self, handlers):
+        result = handlers._handle_resume_process({})
+
+        assert result["status"] == "not_paused"
+
+    def test_get_variables_no_runner(self, handlers):
+        result = handlers._handle_get_variables({})
+
+        assert "variables" in result
+        assert result["variables"] == []
+
+    def test_get_call_stack_no_runner(self, handlers):
+        result = handlers._handle_get_call_stack({})
+
+        assert "callStack" in result
+        assert result["callStack"] == []
+
+    def test_get_breakpoints_no_runner(self, handlers):
+        result = handlers._handle_get_breakpoints({})
+
+        assert result["breakpoints"] == []
+
+
+class TestBridgeDisconnect:
+    """Bridge emits correct events on shutdown / disconnect."""
+
+    def _make_handlers(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        emitted: list[dict] = []
+        engine = StudioEngine()
+        handlers = BridgeHandlers(engine, emit_event=emitted.append)
+        return handlers, emitted
+
+    def test_shutdown_emits_log_event(self):
+        handlers, emitted = self._make_handlers()
+
+        result = asyncio.run(handlers._handle_shutdown({"reason": "test"}))
+
+        assert result["status"] == "shutting_down"
+        assert result["reason"] == "test"
+        log_events = [e for e in emitted if e.get("type") == EventType.LOG.value]
+        assert any("shutdown" in e.get("message", "").lower() for e in log_events)
+
+    def test_shutdown_default_reason(self):
+        handlers, emitted = self._make_handlers()
+
+        result = asyncio.run(handlers._handle_shutdown({}))
+
+        assert result["reason"] == "user_request"
+
+    def test_shutdown_when_no_process_running(self):
+        handlers, emitted = self._make_handlers()
+
+        result = asyncio.run(handlers._handle_shutdown({"reason": "disconnect"}))
+
+        assert result["status"] == "shutting_down"
+        assert handlers._cancel_requested is False
+
+    def test_stop_process_sets_cancel_flag_when_running(self):
+        handlers, _ = self._make_handlers()
+        handlers._process_id = "proc-1"
+
+        class _FakeTask:
+            def done(self):
+                return False
+
+            def cancel(self):
+                pass
+
+        handlers._process_task = _FakeTask()
+        handlers._cancel_requested = False
+
+        handlers._handle_stop_process({})
+
+        assert handlers._cancel_requested is True
+
+
+class TestBridgeEventEmission:
+    """Bridge emits typed events at lifecycle transitions."""
+
+    def test_process_started_event_shape(self):
+        from rpaforge.bridge.events import ProcessStartedEvent
+
+        event = ProcessStartedEvent(process_id="proc-1", name="My Process")
+        data = event.to_dict()
+
+        assert data["type"] == EventType.PROCESS_STARTED.value
+        assert data["processId"] == "proc-1"
+        assert data["name"] == "My Process"
+        assert "timestamp" in data
+
+    def test_process_finished_event_shape(self):
+        from rpaforge.bridge.events import ProcessFinishedEvent
+
+        event = ProcessFinishedEvent(status="pass", duration=1.5)
+        data = event.to_dict()
+
+        assert data["type"] == EventType.PROCESS_FINISHED.value
+        assert data["status"] == "pass"
+        assert data["duration"] == 1.5
+
+    def test_process_stopped_event_shape(self):
+        from rpaforge.bridge.events import ProcessStoppedEvent
+
+        event = ProcessStoppedEvent(reason="user")
+        data = event.to_dict()
+
+        assert data["type"] == EventType.PROCESS_STOPPED.value
+        assert data["reason"] == "user"
+
+    def test_log_event_includes_level_and_message(self):
+        from rpaforge.bridge.events import LogEvent
+
+        event = LogEvent(level="error", message="Something failed", source="engine")
+        data = event.to_dict()
+
+        assert data["type"] == EventType.LOG.value
+        assert data["level"] == "error"
+        assert data["message"] == "Something failed"
+        assert data["source"] == "engine"
+
+    def test_paused_event_includes_node_id(self):
+        from rpaforge.bridge.events import ProcessPausedEvent
+
+        event = ProcessPausedEvent(file="main.py", line=10, node_id="node-42", reason="breakpoint")
+        data = event.to_dict()
+
+        assert data["type"] == EventType.PROCESS_PAUSED.value
+        assert data["nodeId"] == "node-42"
+        assert data["reason"] == "breakpoint"
+
+    def test_resumed_event_type(self):
+        from rpaforge.bridge.events import ProcessResumedEvent
+
+        event = ProcessResumedEvent()
+        data = event.to_dict()
+
+        assert data["type"] == EventType.PROCESS_RESUMED.value

--- a/packages/core/tests/test_cancellation_integration.py
+++ b/packages/core/tests/test_cancellation_integration.py
@@ -1,0 +1,207 @@
+"""Integration tests for process cancellation."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from rpaforge.core.execution import ProcessBuilder
+from rpaforge.core.executor import ProcessExecutor, StopExecution
+from rpaforge.core.runner import ProcessRunner, RunnerState, StudioEngine
+
+
+class TestRunnerCancellation:
+    """ProcessRunner cancel() state transitions."""
+
+    def test_cancel_from_running_transitions_to_cancelling(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+
+        runner.cancel()
+
+        assert runner.state == RunnerState.CANCELLING
+        assert runner._stop_requested is True
+
+    def test_cancel_from_paused_transitions_to_cancelling(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.PAUSED
+        runner._pause_event.clear()
+
+        runner.cancel()
+
+        assert runner.state == RunnerState.CANCELLING
+        assert runner._stop_requested is True
+        assert runner._pause_event.is_set()
+
+    def test_cancel_from_idle_is_noop(self):
+        runner = ProcessRunner()
+
+        runner.cancel()
+
+        assert runner.state == RunnerState.IDLE
+        assert runner._stop_requested is False
+
+    def test_cancel_triggers_callback(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+        called = []
+        runner.on_cancel(lambda: called.append(True))
+
+        runner.cancel()
+
+        assert called == [True]
+
+    def test_stop_sets_stop_requested(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+
+        runner.stop()
+
+        assert runner._stop_requested is True
+
+    def test_cancel_unblocks_paused_event(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.PAUSED
+        runner._pause_event.clear()
+
+        runner.cancel()
+
+        assert runner._pause_event.is_set()
+
+
+class TestEngineCancellation:
+    """StudioEngine cancel() delegates correctly."""
+
+    def test_cancel_while_running_sets_cancelling(self):
+        engine = StudioEngine()
+        engine._runner._state = RunnerState.RUNNING
+
+        engine.cancel()
+
+        assert engine.state == RunnerState.CANCELLING
+        assert engine.stop_requested is True
+
+    def test_cancel_while_idle_is_noop(self):
+        engine = StudioEngine()
+
+        engine.cancel()
+
+        assert engine.state == RunnerState.IDLE
+
+    def test_on_cancel_callback_fires(self):
+        engine = StudioEngine()
+        engine._runner._state = RunnerState.RUNNING
+        fired = []
+        engine.on_cancel(lambda: fired.append(1))
+
+        engine.cancel()
+
+        assert fired == [1]
+
+    def test_cancel_twice_does_not_double_fire_callback(self):
+        engine = StudioEngine()
+        engine._runner._state = RunnerState.RUNNING
+        fired = []
+        engine.on_cancel(lambda: fired.append(1))
+
+        engine.cancel()
+        engine.cancel()
+
+        assert len(fired) == 1
+
+
+class TestCancellationMidExecution:
+    """Cancel stops a process mid-flight."""
+
+    def _make_process_with_sleep(self, sleep_secs: float = 2.0):
+        """Build a process that captures a cancel flag via a mock activity."""
+        import types
+
+        class SleepLib:
+            def sleep_activity(self):
+                time.sleep(sleep_secs)
+
+        lib = SleepLib()
+        executor = ProcessExecutor()
+        executor.register_library("SleepLib", lib)
+
+        builder = ProcessBuilder("Cancel Test")
+        builder.add_task("T1").add_activity("SleepLib", "sleep_activity")
+        return executor, builder.build()
+
+    def test_cancel_during_run_stops_execution(self):
+        runner = ProcessRunner()
+        builder = ProcessBuilder("Cancel Test")
+
+        class MockLib:
+            def noop(self):
+                pass
+
+        runner.executor.register_library("Mock", MockLib())
+        for i in range(20):
+            builder.add_task(f"Task {i}").add_activity("Mock", "noop", node_id=f"n{i}")
+
+        process = builder.build()
+
+        runner._state = RunnerState.IDLE
+        runner._stop_requested = False
+
+        result_holder: list = []
+
+        def run():
+            result_holder.append(runner.run(process))
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+
+        time.sleep(0.05)
+        runner.cancel()
+        t.join(timeout=3.0)
+
+        assert not t.is_alive(), "Runner did not terminate after cancel"
+        assert runner.state != RunnerState.RUNNING
+
+    def test_stop_requested_raises_stop_execution_in_activity(self):
+        runner = ProcessRunner()
+        runner._stop_requested = True
+        runner._state = RunnerState.RUNNING
+
+        from rpaforge.core.execution import ActivityCall
+
+        activity = ActivityCall(library="BuiltIn", activity="noop", node_id="n1")
+
+        with pytest.raises(StopExecution):
+            runner._handle_activity_start(activity)
+
+
+class TestCancellationCallbacks:
+    """Verify callback registration and firing for cancel/stop."""
+
+    def test_multiple_cancel_callbacks_all_fire(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+        log: list[str] = []
+        runner.on_cancel(lambda: log.append("cb1"))
+        runner.on_cancel(lambda: log.append("cb2"))
+
+        runner.cancel()
+
+        assert "cb1" in log
+        assert "cb2" in log
+
+    def test_erroring_callback_does_not_prevent_others(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+        log: list[str] = []
+
+        def bad_cb():
+            raise RuntimeError("oops")
+
+        runner.on_cancel(bad_cb)
+        runner.on_cancel(lambda: log.append("ok"))
+
+        runner.cancel()
+
+        assert "ok" in log

--- a/packages/core/tests/test_cancellation_integration.py
+++ b/packages/core/tests/test_cancellation_integration.py
@@ -117,7 +117,6 @@ class TestCancellationMidExecution:
 
     def _make_process_with_sleep(self, sleep_secs: float = 2.0):
         """Build a process that captures a cancel flag via a mock activity."""
-        import types
 
         class SleepLib:
             def sleep_activity(self):

--- a/packages/core/tests/test_debugger_integration.py
+++ b/packages/core/tests/test_debugger_integration.py
@@ -1,0 +1,314 @@
+"""Integration tests for debugger — breakpoints, stepping, pause/resume."""
+
+from __future__ import annotations
+
+import pytest
+
+from rpaforge.core.runner import ProcessRunner, RunnerState
+
+
+class TestBreakpointManagement:
+    """Add, remove, toggle breakpoints via ProcessRunner."""
+
+    def test_add_breakpoint_returns_breakpoint(self):
+        runner = ProcessRunner()
+
+        bp = runner.add_breakpoint("node-1", line=5)
+
+        assert bp.node_id == "node-1"
+        assert bp.line == 5
+        assert bp.enabled is True
+        assert bp.hit_count == 0
+
+    def test_add_breakpoint_with_condition(self):
+        runner = ProcessRunner()
+
+        bp = runner.add_breakpoint("node-2", line=10, condition="x > 0")
+
+        assert bp.condition == "x > 0"
+
+    def test_add_breakpoint_with_hit_condition(self):
+        runner = ProcessRunner()
+
+        bp = runner.add_breakpoint("node-3", hit_condition=">=3")
+
+        assert bp.hit_condition == ">=3"
+
+    def test_remove_existing_breakpoint_returns_true(self):
+        runner = ProcessRunner()
+        bp = runner.add_breakpoint("node-1")
+
+        removed = runner.remove_breakpoint(bp.id)
+
+        assert removed is True
+
+    def test_remove_missing_breakpoint_returns_false(self):
+        runner = ProcessRunner()
+
+        removed = runner.remove_breakpoint("bp_nonexistent")
+
+        assert removed is False
+
+    def test_toggle_disables_enabled_breakpoint(self):
+        runner = ProcessRunner()
+        bp = runner.add_breakpoint("node-1")
+        assert bp.enabled is True
+
+        result = runner.toggle_breakpoint(bp.id)
+
+        assert result is False
+        assert bp.enabled is False
+
+    def test_toggle_enables_disabled_breakpoint(self):
+        runner = ProcessRunner()
+        bp = runner.add_breakpoint("node-1")
+        runner.toggle_breakpoint(bp.id)
+
+        result = runner.toggle_breakpoint(bp.id)
+
+        assert result is True
+        assert bp.enabled is True
+
+    def test_toggle_missing_breakpoint_returns_none(self):
+        runner = ProcessRunner()
+
+        result = runner.toggle_breakpoint("bp_missing")
+
+        assert result is None
+
+    def test_get_breakpoints_returns_list(self):
+        runner = ProcessRunner()
+        runner.add_breakpoint("node-1")
+        runner.add_breakpoint("node-2")
+
+        bps = runner.get_breakpoints()
+
+        assert len(bps) == 2
+        node_ids = {bp.node_id for bp in bps}
+        assert node_ids == {"node-1", "node-2"}
+
+    def test_get_breakpoints_empty_initially(self):
+        runner = ProcessRunner()
+
+        assert runner.get_breakpoints() == []
+
+    def test_remove_breakpoint_removes_from_list(self):
+        runner = ProcessRunner()
+        bp1 = runner.add_breakpoint("node-1")
+        bp2 = runner.add_breakpoint("node-2")
+
+        runner.remove_breakpoint(bp1.id)
+
+        remaining = [bp.node_id for bp in runner.get_breakpoints()]
+        assert "node-1" not in remaining
+        assert "node-2" in remaining
+        _ = bp2
+
+
+class TestBreakpointHandlers:
+    """BridgeHandlers breakpoint methods with/without active runner."""
+
+    @pytest.fixture
+    def handlers(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        return BridgeHandlers(StudioEngine())
+
+    def test_set_breakpoint_without_runner_creates_pending(self, handlers):
+        result = handlers._handle_set_breakpoint({"nodeId": "n1", "line": 5})
+
+        assert "breakpointId" in result
+        assert result.get("pending") is True
+        assert len(handlers._pending_breakpoints) == 1
+
+    def test_multiple_pending_breakpoints_accumulate(self, handlers):
+        handlers._handle_set_breakpoint({"nodeId": "n1", "line": 1})
+        handlers._handle_set_breakpoint({"nodeId": "n2", "line": 2})
+
+        assert len(handlers._pending_breakpoints) == 2
+
+    def test_remove_breakpoint_without_runner_returns_not_removed(self, handlers):
+        result = handlers._handle_remove_breakpoint({"breakpointId": "bp_x"})
+
+        assert result["removed"] is False
+
+    def test_toggle_breakpoint_without_runner_returns_none(self, handlers):
+        result = handlers._handle_toggle_breakpoint({"breakpointId": "bp_x"})
+
+        assert result["enabled"] is None
+
+    def test_get_breakpoints_without_runner_empty(self, handlers):
+        result = handlers._handle_get_breakpoints({})
+
+        assert result["breakpoints"] == []
+
+    def test_set_breakpoint_with_runner_stores_on_runner(self, handlers):
+        runner = ProcessRunner()
+        handlers._runner = runner
+
+        result = handlers._handle_set_breakpoint({"nodeId": "node-99", "line": 7})
+
+        assert "breakpointId" in result
+        assert result.get("pending") is not True
+        assert len(runner.get_breakpoints()) == 1
+
+    def test_remove_breakpoint_with_runner(self, handlers):
+        runner = ProcessRunner()
+        bp = runner.add_breakpoint("node-1")
+        handlers._runner = runner
+
+        result = handlers._handle_remove_breakpoint({"breakpointId": bp.id})
+
+        assert result["removed"] is True
+
+    def test_get_breakpoints_with_runner(self, handlers):
+        runner = ProcessRunner()
+        runner.add_breakpoint("node-1", line=3)
+        handlers._runner = runner
+
+        result = handlers._handle_get_breakpoints({})
+
+        bps = result["breakpoints"]
+        assert len(bps) == 1
+        assert bps[0]["nodeId"] == "node-1"
+        assert bps[0]["line"] == 3
+        assert bps[0]["enabled"] is True
+
+
+class TestSteppingHandlers:
+    """Step-over / step-into / step-out return correct status."""
+
+    @pytest.fixture
+    def handlers_with_paused_runner(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        handlers = BridgeHandlers(StudioEngine())
+        runner = ProcessRunner()
+        runner._state = RunnerState.PAUSED
+        runner._pause_event.clear()
+        handlers._runner = runner
+        return handlers, runner
+
+    def test_step_over_when_paused(self, handlers_with_paused_runner):
+        handlers, runner = handlers_with_paused_runner
+
+        result = handlers._handle_step_over({})
+
+        assert result["status"] == "stepping"
+        assert runner.state == RunnerState.RUNNING
+        assert runner._step_mode == "over"
+
+    def test_step_into_when_paused(self, handlers_with_paused_runner):
+        handlers, runner = handlers_with_paused_runner
+
+        result = handlers._handle_step_into({})
+
+        assert result["status"] == "stepping"
+        assert runner.state == RunnerState.RUNNING
+        assert runner._step_mode == "into"
+
+    def test_step_out_when_paused(self, handlers_with_paused_runner):
+        handlers, runner = handlers_with_paused_runner
+
+        result = handlers._handle_step_out({})
+
+        assert result["status"] == "stepping"
+        assert runner.state == RunnerState.RUNNING
+        assert runner._step_mode == "out"
+
+    def test_step_over_when_not_paused_returns_not_paused(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        handlers = BridgeHandlers(StudioEngine())
+
+        result = handlers._handle_step_over({})
+
+        assert result["status"] == "not_paused"
+
+    def test_step_into_when_not_paused_returns_not_paused(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        handlers = BridgeHandlers(StudioEngine())
+
+        result = handlers._handle_step_into({})
+
+        assert result["status"] == "not_paused"
+
+    def test_continue_when_paused_resumes(self, handlers_with_paused_runner):
+        handlers, runner = handlers_with_paused_runner
+
+        result = handlers._handle_continue({})
+
+        assert result["status"] == "running"
+        assert runner.state == RunnerState.RUNNING
+
+    def test_continue_when_not_paused_returns_not_paused(self):
+        from rpaforge import StudioEngine
+        from rpaforge.bridge.handlers import BridgeHandlers
+
+        handlers = BridgeHandlers(StudioEngine())
+
+        result = handlers._handle_continue({})
+
+        assert result["status"] == "not_paused"
+
+
+class TestPauseResumeCallbacks:
+    """Pause/resume callbacks are invoked correctly."""
+
+    def test_pause_triggers_pause_callback(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+        paused = []
+        runner.on_pause(lambda frame, node: paused.append(node))
+
+        runner.pause()
+
+        assert len(paused) == 1
+
+    def test_resume_triggers_resume_callback(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.PAUSED
+        runner._pause_event.clear()
+        resumed = []
+        runner.on_resume(lambda: resumed.append(True))
+
+        runner.resume()
+
+        assert resumed == [True]
+
+    def test_resume_from_idle_does_not_fire_callback(self):
+        runner = ProcessRunner()
+        resumed = []
+        runner.on_resume(lambda: resumed.append(True))
+
+        runner.resume()
+
+        assert resumed == []
+
+    def test_pause_from_idle_does_not_fire_callback(self):
+        runner = ProcessRunner()
+        paused = []
+        runner.on_pause(lambda frame, node: paused.append(True))
+
+        runner.pause()
+
+        assert paused == []
+
+    def test_runner_is_paused_property(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.PAUSED
+
+        assert runner.is_paused is True
+        assert runner.is_running is False
+
+    def test_runner_is_running_property(self):
+        runner = ProcessRunner()
+        runner._state = RunnerState.RUNNING
+
+        assert runner.is_running is True
+        assert runner.is_paused is False

--- a/packages/core/tests/test_debugger_integration.py
+++ b/packages/core/tests/test_debugger_integration.py
@@ -264,7 +264,7 @@ class TestPauseResumeCallbacks:
         runner = ProcessRunner()
         runner._state = RunnerState.RUNNING
         paused = []
-        runner.on_pause(lambda frame, node: paused.append(node))
+        runner.on_pause(lambda _frame, node: paused.append(node))
 
         runner.pause()
 
@@ -293,7 +293,7 @@ class TestPauseResumeCallbacks:
     def test_pause_from_idle_does_not_fire_callback(self):
         runner = ProcessRunner()
         paused = []
-        runner.on_pause(lambda frame, node: paused.append(True))
+        runner.on_pause(lambda _frame, _node: paused.append(True))
 
         runner.pause()
 

--- a/packages/studio/src/integration/bridge-lifecycle.test.ts
+++ b/packages/studio/src/integration/bridge-lifecycle.test.ts
@@ -90,8 +90,7 @@ describe('Bridge Lifecycle', () => {
   describe('fatal startup failure simulation', () => {
     it('throws when ElectronBridgeAdapter used without window.rpaforge', async () => {
       const saved = window.rpaforge;
-      // @ts-expect-error intentional
-      delete window.rpaforge;
+      Object.defineProperty(window, 'rpaforge', { value: undefined, writable: true, configurable: true });
 
       const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
       const bridge = new ElectronBridgeAdapter();

--- a/packages/studio/src/integration/bridge-lifecycle.test.ts
+++ b/packages/studio/src/integration/bridge-lifecycle.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MockBridgeAdapter } from '../bridge/mock-bridge';
+import type { BridgeEvent } from '../types/events';
+import { mockElectronAPI } from '../test/integration-setup';
+
+describe('Bridge Lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('ready state detection', () => {
+    it('reports ready after successful start', async () => {
+      const bridge = new MockBridgeAdapter();
+
+      const status = await bridge.start(() => {});
+
+      expect(status.state).toBe('ready');
+      expect(status.isOperational).toBe(true);
+      expect(bridge.isReady()).toBe(true);
+    });
+
+    it('checkReady returns current status', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const status = await bridge.checkReady();
+
+      expect(status.isOperational).toBe(true);
+    });
+
+    it('reports not ready before start', () => {
+      const bridge = new MockBridgeAdapter();
+
+      expect(bridge.isReady()).toBe(false);
+    });
+  });
+
+  describe('disconnect handling', () => {
+    it('stop() transitions bridge to not-ready', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+      expect(bridge.isReady()).toBe(true);
+
+      bridge.stop();
+
+      expect(bridge.isReady()).toBe(false);
+    });
+
+    it('stop() is idempotent — calling twice does not throw', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      bridge.stop();
+      expect(() => bridge.stop()).not.toThrow();
+    });
+
+    it('send() after stop still resolves (mock always responds)', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+      bridge.stop();
+
+      await expect(bridge.send('ping', {})).resolves.toBeDefined();
+    });
+  });
+
+  describe('reconnect behaviour', () => {
+    it('can restart after stop', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+      bridge.stop();
+      expect(bridge.isReady()).toBe(false);
+
+      const status = await bridge.start(() => {});
+
+      expect(status.isOperational).toBe(true);
+      expect(bridge.isReady()).toBe(true);
+    });
+
+    it('second start overwrites previous ready status', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+      bridge.stop();
+
+      const status = await bridge.start(() => {});
+
+      expect(status.state).toBe('ready');
+    });
+  });
+
+  describe('fatal startup failure simulation', () => {
+    it('throws when ElectronBridgeAdapter used without window.rpaforge', async () => {
+      const saved = window.rpaforge;
+      // @ts-expect-error intentional
+      delete window.rpaforge;
+
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+
+      await expect(bridge.start(() => {})).rejects.toThrow('Electron API not available');
+
+      Object.defineProperty(window, 'rpaforge', { value: saved, writable: true, configurable: true });
+    });
+  });
+
+  describe('graceful shutdown', () => {
+    it('event listener is removed after stop', async () => {
+      const received: BridgeEvent[] = [];
+      const { emitBridgeEvent } = mockElectronAPI();
+
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+      await bridge.start((e) => received.push(e));
+
+      bridge.stop();
+
+      emitBridgeEvent({ type: 'log', timestamp: new Date().toISOString(), level: 'info', message: 'after stop' });
+
+      expect(received).toHaveLength(0);
+    });
+
+    it('event listener receives events before stop', async () => {
+      const received: BridgeEvent[] = [];
+      const { emitBridgeEvent } = mockElectronAPI();
+
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+      await bridge.start((e) => received.push(e));
+
+      emitBridgeEvent({ type: 'log', timestamp: new Date().toISOString(), level: 'info', message: 'hello' });
+
+      expect(received).toHaveLength(1);
+      expect((received[0] as { message: string }).message).toBe('hello');
+
+      bridge.stop();
+    });
+  });
+});

--- a/packages/studio/src/integration/runtime.test.tsx
+++ b/packages/studio/src/integration/runtime.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mockElectronAPI } from '../test/integration-setup';
+import { MockBridgeAdapter } from '../bridge/mock-bridge';
+
+describe('Studio Runtime Integration', () => {
+  beforeEach(() => {
+    mockElectronAPI();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('MockBridgeAdapter happy path', () => {
+    it('starts and reports ready state', async () => {
+      const bridge = new MockBridgeAdapter();
+      const events: unknown[] = [];
+
+      const status = await bridge.start((e) => events.push(e));
+
+      expect(status.state).toBe('ready');
+      expect(status.isOperational).toBe(true);
+      expect(bridge.isReady()).toBe(true);
+    });
+
+    it('stops and reports not ready', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      bridge.stop();
+
+      expect(bridge.isReady()).toBe(false);
+    });
+
+    it('sends ping and receives pong', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const result = await bridge.send<{ pong: boolean }>('ping', {});
+
+      expect(result.pong).toBe(true);
+    });
+
+    it('fetches capabilities with expected feature flags', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const caps = await bridge.send<{ version: string; features: Record<string, boolean> }>(
+        'getCapabilities',
+        {}
+      );
+
+      expect(caps.version).toBeTruthy();
+      expect(caps.features.debugger).toBe(true);
+      expect(caps.features.breakpoints).toBe(true);
+    });
+
+    it('fetches activities list', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const result = await bridge.send<{ activities: unknown[] }>('getActivities', {});
+
+      expect(Array.isArray(result.activities)).toBe(true);
+      expect(result.activities.length).toBeGreaterThan(0);
+    });
+
+    it('generates code for empty diagram', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const result = await bridge.send<{ code: string; language: string }>('generateCode', {
+        diagram: {},
+      });
+
+      expect(result.code).toBeTruthy();
+      expect(result.language).toBe('python');
+    });
+
+    it('returns empty variables and call stack', async () => {
+      const bridge = new MockBridgeAdapter();
+      await bridge.start(() => {});
+
+      const vars = await bridge.send<{ variables: unknown[] }>('getVariables', {});
+      const stack = await bridge.send<{ callStack: unknown[] }>('getCallStack', {});
+
+      expect(vars.variables).toHaveLength(0);
+      expect(stack.callStack).toHaveLength(0);
+    });
+  });
+
+  describe('ElectronBridgeAdapter with mocked window.rpaforge', () => {
+    it('start() resolves to ready status when window.rpaforge is present', async () => {
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+
+      const status = await bridge.start(() => {});
+
+      expect(status.isOperational).toBe(true);
+      expect(bridge.isReady()).toBe(true);
+    });
+
+    it('stop() unsubscribes from events', async () => {
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+      await bridge.start(() => {});
+
+      bridge.stop();
+
+      expect(bridge.isReady()).toBe(false);
+    });
+
+    it('send() delegates to window.rpaforge.bridge.send', async () => {
+      const { ElectronBridgeAdapter } = await import('../bridge/electron-bridge');
+      const bridge = new ElectronBridgeAdapter();
+      await bridge.start(() => {});
+
+      await bridge.send('ping', {});
+
+      expect(window.rpaforge!.bridge.send).toHaveBeenCalledWith('ping', {});
+    });
+  });
+
+  describe('bridge factory routing', () => {
+    it('creates MockBridgeAdapter when window.rpaforge is absent', async () => {
+      const saved = window.rpaforge;
+      // @ts-expect-error - intentionally removing for test
+      delete window.rpaforge;
+
+      const { createBridgeAdapter } = await import('../bridge/factory');
+      const bridge = createBridgeAdapter();
+
+      expect(bridge.transport).toBe('mock');
+
+      Object.defineProperty(window, 'rpaforge', { value: saved, writable: true, configurable: true });
+    });
+
+    it('creates ElectronBridgeAdapter when window.rpaforge is present', async () => {
+      const { createBridgeAdapter } = await import('../bridge/factory');
+      const bridge = createBridgeAdapter();
+
+      expect(bridge.transport).toBe('electron');
+    });
+  });
+});

--- a/packages/studio/src/integration/runtime.test.tsx
+++ b/packages/studio/src/integration/runtime.test.tsx
@@ -124,8 +124,7 @@ describe('Studio Runtime Integration', () => {
   describe('bridge factory routing', () => {
     it('creates MockBridgeAdapter when window.rpaforge is absent', async () => {
       const saved = window.rpaforge;
-      // @ts-expect-error - intentionally removing for test
-      delete window.rpaforge;
+      Object.defineProperty(window, 'rpaforge', { value: undefined, writable: true, configurable: true });
 
       const { createBridgeAdapter } = await import('../bridge/factory');
       const bridge = createBridgeAdapter();

--- a/packages/studio/src/test/integration-setup.ts
+++ b/packages/studio/src/test/integration-setup.ts
@@ -1,0 +1,115 @@
+import { vi } from 'vitest';
+import type { BridgeEvent, BridgeStatus, FileSystemEvent } from '../types/events';
+
+function makeReadyStatus(): BridgeStatus {
+  return {
+    timestamp: new Date().toISOString(),
+    state: 'ready',
+    previousState: 'stopped',
+    isOperational: true,
+    maxReconnectAttempts: 3,
+    consecutiveHeartbeatFailures: 0,
+    fatal: false,
+    reason: 'ready_check',
+  };
+}
+
+export function mockElectronAPI() {
+  const eventListeners: Array<(event: BridgeEvent) => void> = [];
+
+  const api = {
+    bridge: {
+      isReady: vi.fn().mockResolvedValue(true),
+      getState: vi.fn().mockResolvedValue('ready'),
+      getStatus: vi.fn().mockResolvedValue(makeReadyStatus()),
+      send: vi.fn().mockImplementation((method: string) => {
+        const responses: Record<string, unknown> = {
+          ping: { pong: true, timestamp: Date.now() },
+          getCapabilities: {
+            version: '0.3.0',
+            features: {
+              debugger: true,
+              breakpoints: true,
+              stepping: true,
+              variableWatching: true,
+              nativePython: true,
+            },
+            libraries: ['DesktopUI', 'WebUI', 'BuiltIn'],
+          },
+          getActivities: { activities: [] },
+          runProcess: { status: 'pass', duration: 0.1 },
+          stopProcess: {},
+          getVariables: { variables: [] },
+          getCallStack: { callStack: [] },
+          getBreakpoints: { breakpoints: [] },
+          generateCode: { code: 'def main():\n    pass\n', language: 'python' },
+        };
+        return Promise.resolve(responses[method] ?? {});
+      }),
+      onEvent: vi.fn().mockImplementation((listener: (event: BridgeEvent) => void) => {
+        eventListeners.push(listener);
+        return () => {
+          const idx = eventListeners.indexOf(listener);
+          if (idx !== -1) eventListeners.splice(idx, 1);
+        };
+      }),
+    },
+
+    engine: {
+      ping: vi.fn().mockResolvedValue({ pong: true }),
+      getCapabilities: vi.fn().mockResolvedValue({
+        version: '0.3.0',
+        features: { debugger: true, breakpoints: true },
+        libraries: ['BuiltIn'],
+      }),
+      runProcess: vi.fn().mockResolvedValue({ status: 'pass', duration: 0.1 }),
+      runFile: vi.fn().mockResolvedValue({ status: 'pass', duration: 0.1 }),
+      stopProcess: vi.fn().mockResolvedValue({}),
+      pauseProcess: vi.fn().mockResolvedValue({}),
+      resumeProcess: vi.fn().mockResolvedValue({}),
+      getActivities: vi.fn().mockResolvedValue({ activities: [] }),
+    },
+
+    debugger: {
+      setBreakpoint: vi.fn().mockResolvedValue({ id: 'bp-1' }),
+      removeBreakpoint: vi.fn().mockResolvedValue({}),
+      toggleBreakpoint: vi.fn().mockResolvedValue({}),
+      getBreakpoints: vi.fn().mockResolvedValue({ breakpoints: [] }),
+      stepOver: vi.fn().mockResolvedValue({}),
+      stepInto: vi.fn().mockResolvedValue({}),
+      stepOut: vi.fn().mockResolvedValue({}),
+      continue: vi.fn().mockResolvedValue({}),
+      getVariables: vi.fn().mockResolvedValue({ variables: [] }),
+      getCallStack: vi.fn().mockResolvedValue({ callStack: [] }),
+    },
+
+    dialog: {
+      showOpenDialog: vi.fn().mockResolvedValue({ canceled: true, filePaths: [] }),
+      showSaveDialog: vi.fn().mockResolvedValue({ canceled: true, filePath: undefined }),
+    },
+
+    fs: {
+      pathExists: vi.fn().mockResolvedValue(false),
+      readDir: vi.fn().mockResolvedValue([]),
+      readFile: vi.fn().mockResolvedValue(''),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      createDir: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      rename: vi.fn().mockResolvedValue(undefined),
+      copy: vi.fn().mockResolvedValue(undefined),
+      openWithSystem: vi.fn().mockResolvedValue(undefined),
+      showInFolder: vi.fn().mockResolvedValue(undefined),
+      getFileInfo: vi.fn().mockResolvedValue(null),
+      watchDir: vi.fn().mockResolvedValue(undefined),
+      unwatchDir: vi.fn().mockResolvedValue(undefined),
+      onFsEvent: vi.fn().mockImplementation((_listener: (event: FileSystemEvent) => void) => () => {}),
+    },
+  };
+
+  Object.defineProperty(window, 'rpaforge', { value: api, writable: true, configurable: true });
+
+  return {
+    api,
+    emitBridgeEvent: (event: BridgeEvent) => eventListeners.forEach((l) => l(event)),
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `mockElectronAPI()` test helper that creates a full `vi.fn()` mock of `window.rpaforge` (bridge/engine/debugger/dialog/fs namespaces) for TypeScript tests
- Adds TypeScript integration tests for `MockBridgeAdapter` and `ElectronBridgeAdapter` lifecycle, bridge factory routing, and event listener cleanup (issues #66 and #67)
- Adds Python integration tests for bridge ready/shutdown events, process cancellation state machine, and debugger breakpoint/stepping/pause/resume (issues #67 and #68)

## Test plan

- [x] `npm test -- --run` → 29 test files, 132 tests passing
- [x] `pytest packages/core/tests/test_bridge_lifecycle.py packages/core/tests/test_cancellation_integration.py packages/core/tests/test_debugger_integration.py` → 64 tests passing
- [x] Full Python suite (`pytest packages/core/tests/`) → 125 passing (1 pre-existing failure in test_bridge.py due to missing pytest-asyncio)

Closes #66
Closes #67
Closes #68
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)