### PR TITLE
feat: execution engine abstraction layer for DI and testability (#87)

### DIFF
--- a/packages/core/src/rpaforge/core/__init__.py
+++ b/packages/core/src/rpaforge/core/__init__.py
@@ -16,6 +16,14 @@ from rpaforge.core.execution import (
     Variable,
 )
 from rpaforge.core.executor import ErrorContext, ExecutionError, TimeoutError
+from rpaforge.core.interfaces import (
+    EventEmitter,
+    ExecutionEvent,
+    Executor,
+    ExpressionEvaluator,
+    LibraryProvider,
+    TimeoutHandler,
+)
 
 __all__ = [
     "ActivityCall",
@@ -24,10 +32,16 @@ __all__ = [
     "ExecutionError",
     "ExecutionResult",
     "ExecutionStatus",
+    "EventEmitter",
+    "ExecutionEvent",
+    "Executor",
+    "ExpressionEvaluator",
+    "LibraryProvider",
     "Process",
     "ProcessBuilder",
     "Task",
     "TaskBuilder",
     "TimeoutError",
+    "TimeoutHandler",
     "Variable",
 ]

--- a/packages/core/src/rpaforge/core/execution.py
+++ b/packages/core/src/rpaforge/core/execution.py
@@ -220,3 +220,56 @@ class ProcessBuilder:
 
     def build(self) -> Process:
         return self._process
+
+
+@dataclass
+class ExecutionContext:
+    """Runtime execution context."""
+
+    variables: dict[str, Any]
+    process: Process | None = None
+    task: Task | None = None
+    current_activity: ActivityCall | None = None
+    call_stack: list[ActivityCall] = None
+
+    def __post_init__(self):
+        if self.call_stack is None:
+            self.call_stack = []
+
+    def get_variable(self, name: str, default: Any = None) -> Any:
+        return self.variables.get(name, default)
+
+    def set_variable(self, name: str, value: Any) -> None:
+        self.variables[name] = value
+
+    def resolve_value(self, value: Any) -> Any:
+        if isinstance(value, str) and value and self._is_variable_reference(value):
+            return self.variables.get(value, value)
+
+        if isinstance(value, (list, tuple)):
+            return [self.resolve_value(v) for v in value]
+        if isinstance(value, dict):
+            return {k: self.resolve_value(v) for k, v in value.items()}
+        return value
+
+    def _is_variable_reference(self, value: str) -> bool:
+        if not value or not isinstance(value, str):
+            return False
+
+        if value.startswith(("'", '"', "/", "\\")) or ":" in value[:3]:
+            return False
+
+        if value.isdigit() or value in ("True", "False", "None"):
+            return False
+
+        is_var = value.isidentifier()
+
+        if not is_var:
+            if "." in value:
+                parts = value.split(".")
+                is_var = all(part.isidentifier() for part in parts)
+            elif "[" in value and "]" in value:
+                base = value.split("[")[0]
+                is_var = base.isidentifier()
+
+        return is_var

--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -26,6 +26,11 @@ from rpaforge.core.execution import (
     Process,
     Task,
 )
+from rpaforge.core.interfaces import (
+    ExpressionEvaluator,
+    LibraryProvider,
+    TimeoutHandler,
+)
 
 if TYPE_CHECKING:
     pass
@@ -54,6 +59,73 @@ except ImportError:
     SubprocessExecutor = None
 
 logger = logging.getLogger("rpaforge")
+
+
+class DefaultLibraryProvider:
+    """Default implementation using the global LIBRARY_REGISTRY."""
+
+    def get_library(self, name: str) -> type | None:
+        entry = LIBRARY_REGISTRY.get(name)
+        if entry is None:
+            return None
+        cls, _ = entry
+        return cls
+
+    def instantiate_library(self, cls: type) -> Any:
+        return cls()
+
+
+class ThreadingTimeoutHandler:
+    """Timeout execution using SubprocessExecutor or threading fallback."""
+
+    def execute_with_timeout(
+        self,
+        func: Callable[..., Any],
+        args: tuple[Any, ...],
+        timeout_ms: int,
+    ) -> Any:
+        if _USE_SUBPROCESS and SubprocessExecutor is not None:
+            # func here is a bound method; extract library path and activity name
+            # for SubprocessExecutor which needs module-level access.
+            # Fall through to threading when the method is already resolved.
+            pass
+
+        result_container: list[Any] = []
+        exception_container: list[Exception] = []
+        _thread_lock = threading.Lock()
+
+        def run_in_thread() -> None:
+            try:
+                output = func(*args)
+                with _thread_lock:
+                    result_container.append(output)
+            except Exception as e:
+                with _thread_lock:
+                    exception_container.append(e)
+
+        thread = threading.Thread(target=run_in_thread, daemon=True)
+        thread.start()
+        thread.join(timeout=timeout_ms / 1000.0)
+
+        with _thread_lock:
+            timed_out = thread.is_alive()
+            has_exception = bool(exception_container)
+            exc = exception_container[0] if has_exception else None
+            has_result = bool(result_container)
+            res = result_container[0] if has_result else None
+
+        if timed_out:
+            raise TimeoutError(timeout_ms)
+        if has_exception:
+            raise exc  # type: ignore[misc]
+        return res
+
+
+class SafeExpressionEvaluator:
+    """Expression evaluator backed by safe_eval."""
+
+    def evaluate(self, expression: str, variables: dict[str, Any]) -> Any:
+        return safe_eval(expression, variables)
 
 
 @dataclass
@@ -199,7 +271,15 @@ class ExecutionContext:
 class ProcessExecutor:
     """Native Python executor for RPAForge processes."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        library_provider: LibraryProvider | None = None,
+        timeout_handler: TimeoutHandler | None = None,
+        expression_evaluator: ExpressionEvaluator | None = None,
+    ) -> None:
+        self._library_provider = library_provider or DefaultLibraryProvider()
+        self._timeout_handler = timeout_handler or ThreadingTimeoutHandler()
+        self._evaluator = expression_evaluator or SafeExpressionEvaluator()
         self._libraries: dict[str, Any] = {}
         self._listeners: list[Callable] = []
         self._context: ExecutionContext | None = None
@@ -215,6 +295,9 @@ class ProcessExecutor:
     def remove_listener(self, callback: Callable) -> None:
         if callback in self._listeners:
             self._listeners.remove(callback)
+
+    def cancel(self) -> None:
+        pass
 
     def run(self, process: Process) -> ExecutionResult:
         start_time = perf_counter()
@@ -469,9 +552,9 @@ class ProcessExecutor:
         lib_instance = self._libraries.get(library)
 
         if lib_instance is None:
-            cls, _ = LIBRARY_REGISTRY.get(library, (None, None))
+            cls = self._library_provider.get_library(library)
             if cls is not None:
-                lib_instance = cls()
+                lib_instance = self._library_provider.instantiate_library(cls)
                 self._libraries[library] = lib_instance
             else:
                 raise ExecutionError(f"Library '{library}' not found")
@@ -493,10 +576,7 @@ class ProcessExecutor:
 
         # Use subprocess executor if available for safe timeout handling
         if _USE_SUBPROCESS and SubprocessExecutor is not None:
-            # Get library path from the library name
-            # e.g., "DesktopUI" -> "rpaforge_libraries.DesktopUI"
             lib_path = f"rpaforge_libraries.{library}"
-
             executor = SubprocessExecutor()
             try:
                 return executor.execute_with_timeout(
@@ -508,41 +588,11 @@ class ProcessExecutor:
                 )
             finally:
                 executor.close()
-        else:
-            # Fallback to threading if subprocess not available
-            # This maintains backward compatibility
-            result_container: list[Any] = []
-            exception_container: list[Exception] = []
-            # Protect shared state between the spawned thread and this thread.
-            _thread_lock = threading.Lock()
 
-            def run_in_thread() -> None:
-                try:
-                    output = method(*args, **kwargs)
-                    with _thread_lock:
-                        result_container.append(output)
-                except Exception as e:
-                    with _thread_lock:
-                        exception_container.append(e)
+        def _call(*a: Any) -> Any:
+            return method(*a[: len(args)], **kwargs)
 
-            thread = threading.Thread(target=run_in_thread, daemon=True)
-            thread.start()
-            thread.join(timeout=timeout_ms / 1000.0)
-
-            with _thread_lock:
-                timed_out = thread.is_alive()
-                has_exception = bool(exception_container)
-                exc = exception_container[0] if has_exception else None
-                has_result = bool(result_container)
-                res = result_container[0] if has_result else None
-
-            if timed_out:
-                raise TimeoutError(timeout_ms)
-
-            if has_exception:
-                raise exc
-
-            return res
+        return self._timeout_handler.execute_with_timeout(_call, args, timeout_ms)
 
     def _notify(self, event_type: str, *args: Any) -> None:
         for listener in self._listeners:

--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -14,13 +14,14 @@ import traceback
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from time import perf_counter
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from rpaforge.core.activity import (
     LIBRARY_REGISTRY,
 )
 from rpaforge.core.execution import (
     ActivityCall,
+    ExecutionContext,
     ExecutionResult,
     ExecutionStatus,
     Process,
@@ -31,9 +32,6 @@ from rpaforge.core.interfaces import (
     LibraryProvider,
     TimeoutHandler,
 )
-
-if TYPE_CHECKING:
-    pass
 
 # Import safe execution modules
 try:
@@ -109,15 +107,13 @@ class ThreadingTimeoutHandler:
 
         with _thread_lock:
             timed_out = thread.is_alive()
-            has_exception = bool(exception_container)
-            exc = exception_container[0] if has_exception else None
             has_result = bool(result_container)
             res = result_container[0] if has_result else None
 
         if timed_out:
             raise TimeoutError(timeout_ms)
-        if has_exception:
-            raise exc  # type: ignore[misc]
+        if exception_container:
+            raise exception_container[0]
         return res
 
 
@@ -210,62 +206,6 @@ class StopExecution(Exception):
     """Raised to stop execution gracefully."""
 
     pass
-
-
-@dataclass
-class ExecutionContext:
-    """Runtime execution context."""
-
-    variables: dict[str, Any]
-    process: Process | None = None
-    task: Task | None = None
-    current_activity: ActivityCall | None = None
-    call_stack: list[ActivityCall] = None
-
-    def __post_init__(self):
-        if self.call_stack is None:
-            self.call_stack = []
-
-    def get_variable(self, name: str, default: Any = None) -> Any:
-        return self.variables.get(name, default)
-
-    def set_variable(self, name: str, value: Any) -> None:
-        self.variables[name] = value
-
-    def resolve_value(self, value: Any) -> Any:
-        if isinstance(value, str) and value and self._is_variable_reference(value):
-            return self.variables.get(value, value)
-
-        if isinstance(value, (list, tuple)):
-            return [self.resolve_value(v) for v in value]
-        if isinstance(value, dict):
-            return {k: self.resolve_value(v) for k, v in value.items()}
-        return value
-
-    def _is_variable_reference(self, value: str) -> bool:
-        if not value or not isinstance(value, str):
-            return False
-
-        if value.startswith(("'", '"', "/", "\\")) or ":" in value[:3]:
-            return False
-
-        if value.isdigit() or value in ("True", "False", "None"):
-            return False
-
-        # Check if it's a valid Python identifier (potential variable)
-        is_var = value.isidentifier()
-
-        if not is_var:
-            # Check for attribute access (e.g., "obj.attr")
-            if "." in value:
-                parts = value.split(".")
-                is_var = all(part.isidentifier() for part in parts)
-            # Check for indexing (e.g., "list[0]")
-            elif "[" in value and "]" in value:
-                base = value.split("[")[0]
-                is_var = base.isidentifier()
-
-        return is_var
 
 
 class ProcessExecutor:

--- a/packages/core/src/rpaforge/core/interfaces.py
+++ b/packages/core/src/rpaforge/core/interfaces.py
@@ -1,0 +1,74 @@
+"""
+RPAForge Core Protocol Abstractions.
+
+Protocol-based interfaces for dependency injection and testability.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from rpaforge.core.execution import ExecutionResult, Process
+    from rpaforge.core.executor import ExecutionContext
+
+
+@dataclass
+class ExecutionEvent:
+    """An event emitted during process execution."""
+
+    event_type: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Executor(Protocol):
+    """Abstracts ProcessExecutor for dependency injection."""
+
+    def run(self, process: Process) -> ExecutionResult: ...
+
+    def add_listener(self, callback: Callable[..., None]) -> None: ...
+
+    def remove_listener(self, callback: Callable[..., None]) -> None: ...
+
+    @property
+    def context(self) -> ExecutionContext | None: ...
+
+    def cancel(self) -> None: ...
+
+
+@runtime_checkable
+class LibraryProvider(Protocol):
+    """Abstracts access to the library registry."""
+
+    def get_library(self, name: str) -> type | None: ...
+
+    def instantiate_library(self, cls: type) -> Any: ...
+
+
+@runtime_checkable
+class TimeoutHandler(Protocol):
+    """Abstracts subprocess/threading timeout execution."""
+
+    def execute_with_timeout(
+        self,
+        func: Callable[..., Any],
+        args: tuple[Any, ...],
+        timeout_ms: int,
+    ) -> Any: ...
+
+
+@runtime_checkable
+class ExpressionEvaluator(Protocol):
+    """Abstracts safe_eval for condition evaluation."""
+
+    def evaluate(self, expression: str, variables: dict[str, Any]) -> Any: ...
+
+
+@runtime_checkable
+class EventEmitter(Protocol):
+    """Abstracts event emission during execution."""
+
+    def emit(self, event: ExecutionEvent) -> None: ...

--- a/packages/core/src/rpaforge/core/interfaces.py
+++ b/packages/core/src/rpaforge/core/interfaces.py
@@ -11,8 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from rpaforge.core.execution import ExecutionResult, Process
-    from rpaforge.core.executor import ExecutionContext
+    from rpaforge.core.execution import ExecutionContext, ExecutionResult, Process
 
 
 @dataclass

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -20,6 +20,7 @@ from rpaforge.core.execution import (
     Process,
 )
 from rpaforge.core.executor import ProcessExecutor, StopExecution
+from rpaforge.core.interfaces import Executor
 
 if TYPE_CHECKING:
     pass
@@ -76,8 +77,8 @@ class CallFrame:
 class ProcessRunner:
     """Process runner with debugging support."""
 
-    def __init__(self, executor: ProcessExecutor | None = None):
-        self._executor = executor or ProcessExecutor()
+    def __init__(self, executor: Executor | None = None):
+        self._executor: Executor = executor or ProcessExecutor()
         self._state = RunnerState.IDLE
         self._pause_event = threading.Event()
         self._pause_event.set()
@@ -111,7 +112,7 @@ class ProcessRunner:
         return self._state == RunnerState.PAUSED
 
     @property
-    def executor(self) -> ProcessExecutor:
+    def executor(self) -> Executor:
         return self._executor
 
     def run(self, process: Process) -> ExecutionResult:
@@ -399,14 +400,19 @@ class ProcessRunner:
 class StudioEngine:
     """Main engine for RPAForge (compatibility layer with old API)."""
 
-    def __init__(self, debugger: Any | None = None, output_dir: str | None = None):
-        self._runner = ProcessRunner()
+    def __init__(
+        self,
+        executor: Executor | None = None,
+        debugger: Any | None = None,
+        output_dir: str | None = None,
+    ):
+        self._runner = ProcessRunner(executor=executor)
         self._debugger = debugger
         self._output_dir = output_dir
         self._is_running = False
 
     @property
-    def executor(self) -> ProcessExecutor:
+    def executor(self) -> Executor:
         return self._runner._executor
 
     @property

--- a/packages/core/src/rpaforge/engine/__init__.py
+++ b/packages/core/src/rpaforge/engine/__init__.py
@@ -14,6 +14,14 @@ from rpaforge.core.execution import (
     Task,
     TaskBuilder,
 )
+from rpaforge.core.interfaces import (
+    EventEmitter,
+    ExecutionEvent,
+    Executor,
+    ExpressionEvaluator,
+    LibraryProvider,
+    TimeoutHandler,
+)
 from rpaforge.core.runner import (
     Breakpoint,
     CallFrame,
@@ -36,4 +44,10 @@ __all__ = [
     "Breakpoint",
     "CallFrame",
     "RunnerState",
+    "EventEmitter",
+    "ExecutionEvent",
+    "Executor",
+    "ExpressionEvaluator",
+    "LibraryProvider",
+    "TimeoutHandler",
 ]

--- a/packages/core/tests/test_engine.py
+++ b/packages/core/tests/test_engine.py
@@ -5,6 +5,7 @@ from rpaforge.core.execution import (
     Process,
     ProcessBuilder,
 )
+from rpaforge.core.interfaces import ExecutionEvent, Executor
 from rpaforge.core.runner import ProcessRunner, RunnerState, StudioEngine
 
 
@@ -182,3 +183,61 @@ class TestProcess:
     def test_get_variable_default(self):
         process = Process(name="Test")
         assert process.get_variable("missing", "default") == "default"
+
+
+class MockExecutor:
+    """Mock executor implementing the Executor Protocol for testing."""
+
+    def __init__(self):
+        self.calls = []
+        self._context = None
+
+    def run(self, process):
+        self.calls.append(("run", process))
+        return None
+
+    def add_listener(self, callback):
+        self.calls.append(("add_listener", callback))
+
+    def remove_listener(self, callback):
+        self.calls.append(("remove_listener", callback))
+
+    def cancel(self):
+        self.calls.append(("cancel",))
+
+    @property
+    def context(self):
+        return self._context
+
+
+class TestExecutorProtocol:
+    """Tests for Executor Protocol abstractions."""
+
+    def test_mock_executor_satisfies_protocol(self):
+        mock = MockExecutor()
+        assert isinstance(mock, Executor)
+
+    def test_process_runner_accepts_mock_executor(self):
+        mock = MockExecutor()
+        runner = ProcessRunner(executor=mock)
+        assert runner.executor is mock
+
+    def test_mock_executor_add_listener_called_on_init(self):
+        mock = MockExecutor()
+        ProcessRunner(executor=mock)
+        listener_calls = [c for c in mock.calls if c[0] == "add_listener"]
+        assert len(listener_calls) == 1
+
+    def test_studio_engine_accepts_mock_executor(self):
+        mock = MockExecutor()
+        engine = StudioEngine(executor=mock)
+        assert engine.executor is mock
+
+    def test_execution_event_dataclass(self):
+        event = ExecutionEvent(event_type="start_process", data={"name": "Test"})
+        assert event.event_type == "start_process"
+        assert event.data["name"] == "Test"
+
+    def test_execution_event_default_data(self):
+        event = ExecutionEvent(event_type="end_process")
+        assert event.data == {}


### PR DESCRIPTION
## Summary

- Introduces `core/interfaces.py` with six `@runtime_checkable` Protocol abstractions: `Executor`, `LibraryProvider`, `TimeoutHandler`, `ExpressionEvaluator`, `EventEmitter`, `ExecutionEvent`
- Refactors `ProcessExecutor` to accept optional DI parameters with backward-compatible defaults (`DefaultLibraryProvider`, `ThreadingTimeoutHandler`, `SafeExpressionEvaluator`)
- Updates `ProcessRunner` and `StudioEngine` to accept `Executor` Protocol instead of the concrete class

Closes #87

## Test plan

- [ ] All existing tests pass (`pytest packages/core/tests/ -v`)
- [ ] New `TestExecutorProtocol` suite (6 tests) covers Protocol runtime checks and DI injection into `ProcessRunner`/`StudioEngine`
- [ ] `ProcessExecutor()` with no arguments behaves identically to before (backward compatibility)
- [ ] CI passes on Python 3.10, 3.11, 3.12, 3.13