### PR TITLE
feat(core): implement retry circuit breaker pattern

### DIFF
--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import datetime
+import enum
 import logging
 import re
 import threading

--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -15,6 +15,7 @@ import time
 import traceback
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import Enum
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
@@ -239,6 +240,24 @@ class StopExecution(Exception):
     pass
 
 
+class CircuitState(Enum):
+    """Circuit breaker states for activity reliability."""
+
+    CLOSED = "closed"  # Normal operation, attempts allowed
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+@dataclass
+class CircuitBreakerState:
+    """State tracking for circuit breaker pattern."""
+
+    failures: int = 0
+    last_failure_time: float = 0.0
+    state: CircuitState = CircuitState.CLOSED
+    state_changed_at: float = 0.0
+
+
 class ProcessExecutor:
     """Native Python executor for RPAForge processes."""
 
@@ -260,6 +279,7 @@ class ProcessExecutor:
             if _USE_SUBPROCESS and SubprocessExecutor is not None
             else None
         )
+        self._circuit_breakers: dict[str, CircuitBreakerState] = {}
 
     def register_library(self, name: str, instance: Any) -> None:
         self._libraries[name] = instance
@@ -463,6 +483,15 @@ class ProcessExecutor:
                 k: self._context.resolve_value(v) for k, v in activity.kwargs.items()
             }
 
+            allowed, circuit_status = self._check_circuit_breaker(activity)
+            if not allowed:
+                raise ExecutionError(
+                    f"Circuit breaker {circuit_status} for {activity.library}.{activity.activity}"
+                )
+
+            if circuit_status:
+                logger.info(f"Circuit breaker {circuit_status} for {activity.library}.{activity.activity}")
+
             while True:
                 try:
                     output = self._execute_activity(
@@ -472,6 +501,8 @@ class ProcessExecutor:
                         timeout_ms=activity.timeout_ms,
                         **resolved_kwargs,
                     )
+
+                    self._update_circuit_breaker(activity, success=True)
 
                     result["output"] = output
                     result["elapsed_ms"] = int((perf_counter() - start_time) * 1000)
@@ -501,6 +532,7 @@ class ProcessExecutor:
                         )
                         time.sleep(max(delay_ms / 1000.0, 0.001))
                     else:
+                        self._update_circuit_breaker(activity, success=False)
                         raise
 
         except StopExecution:
@@ -656,3 +688,56 @@ class ProcessExecutor:
         if self._context:
             return dict(self._context.variables)
         return {}
+
+    def _get_circuit_key(self, activity: ActivityCall) -> str:
+        return f"{activity.library}.{activity.activity}"
+
+    def _check_circuit_breaker(self, activity: ActivityCall) -> tuple[bool, str | None]:
+        circuit_key = self._get_circuit_key(activity)
+        if circuit_key not in self._circuit_breakers:
+            return True, None
+
+        state = self._circuit_breakers[circuit_key]
+        now = time.time()
+
+        if state.state == CircuitState.OPEN:
+            if now - state.state_changed_at >= 60.0:
+                state.state = CircuitState.HALF_OPEN
+                state.state_changed_at = now
+                logger.info(f"Circuit breaker HALF_OPEN for {circuit_key}: testing recovery")
+                return True, "HALF_OPEN (testing recovery)"
+            return False, "OPEN (circuit tripped)"
+
+        if state.state == CircuitState.HALF_OPEN:
+            return True, "HALF_OPEN (recovery test)"
+
+        return True, None
+
+    def _update_circuit_breaker(self, activity: ActivityCall, success: bool) -> None:
+        circuit_key = self._get_circuit_key(activity)
+        if circuit_key not in self._circuit_breakers:
+            self._circuit_breakers[circuit_key] = CircuitBreakerState()
+
+        state = self._circuit_breakers[circuit_key]
+        now = time.time()
+
+        if success:
+            if state.state == CircuitState.HALF_OPEN:
+                state.state = CircuitState.CLOSED
+                state.failures = 0
+                state.state_changed_at = now
+                logger.info(f"Circuit breaker CLOSED for {circuit_key}: service recovered")
+            elif state.state == CircuitState.CLOSED:
+                state.failures = 0
+        else:
+            state.failures += 1
+            state.last_failure_time = now
+
+            if state.state == CircuitState.HALF_OPEN:
+                state.state = CircuitState.OPEN
+                state.state_changed_at = now
+                logger.warning(f"Circuit breaker OPEN for {circuit_key}: recovery test failed")
+            elif state.state == CircuitState.CLOSED and state.failures >= 3:
+                state.state = CircuitState.OPEN
+                state.state_changed_at = now
+                logger.warning(f"Circuit breaker OPEN for {circuit_key}: {state.failures} consecutive failures")

--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import concurrent.futures
 import datetime
-import enum
 import logging
 import re
 import threading
@@ -491,7 +490,9 @@ class ProcessExecutor:
                 )
 
             if circuit_status:
-                logger.info(f"Circuit breaker {circuit_status} for {activity.library}.{activity.activity}")
+                logger.info(
+                    f"Circuit breaker {circuit_status} for {activity.library}.{activity.activity}"
+                )
 
             while True:
                 try:
@@ -705,7 +706,9 @@ class ProcessExecutor:
             if now - state.state_changed_at >= 60.0:
                 state.state = CircuitState.HALF_OPEN
                 state.state_changed_at = now
-                logger.info(f"Circuit breaker HALF_OPEN for {circuit_key}: testing recovery")
+                logger.info(
+                    f"Circuit breaker HALF_OPEN for {circuit_key}: testing recovery"
+                )
                 return True, "HALF_OPEN (testing recovery)"
             return False, "OPEN (circuit tripped)"
 
@@ -727,7 +730,9 @@ class ProcessExecutor:
                 state.state = CircuitState.CLOSED
                 state.failures = 0
                 state.state_changed_at = now
-                logger.info(f"Circuit breaker CLOSED for {circuit_key}: service recovered")
+                logger.info(
+                    f"Circuit breaker CLOSED for {circuit_key}: service recovered"
+                )
             elif state.state == CircuitState.CLOSED:
                 state.failures = 0
         else:
@@ -737,8 +742,12 @@ class ProcessExecutor:
             if state.state == CircuitState.HALF_OPEN:
                 state.state = CircuitState.OPEN
                 state.state_changed_at = now
-                logger.warning(f"Circuit breaker OPEN for {circuit_key}: recovery test failed")
+                logger.warning(
+                    f"Circuit breaker OPEN for {circuit_key}: recovery test failed"
+                )
             elif state.state == CircuitState.CLOSED and state.failures >= 3:
                 state.state = CircuitState.OPEN
                 state.state_changed_at = now
-                logger.warning(f"Circuit breaker OPEN for {circuit_key}: {state.failures} consecutive failures")
+                logger.warning(
+                    f"Circuit breaker OPEN for {circuit_key}: {state.failures} consecutive failures"
+                )

--- a/packages/core/tests/test_circuit_breaker.py
+++ b/packages/core/tests/test_circuit_breaker.py
@@ -1,0 +1,138 @@
+: """Tests for Circuit Breaker functionality in ProcessExecutor."""
+
+import time
+
+from rpaforge.core.execution import ActivityCall
+from rpaforge.core.executor import CircuitState, ProcessExecutor
+
+
+class TestCircuitBreaker:
+    """Tests for circuit breaker pattern implementation."""
+
+    def test_circuit_breaker_initially_closed(self):
+        """Circuit breaker should start in CLOSED state."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="test_activity", args=())
+
+        allowed, status = executor._check_circuit_breaker(activity)
+
+        assert allowed is True
+        assert status is None
+        circuit_key = executor._get_circuit_key(activity)
+        assert circuit_key not in executor._circuit_breakers
+
+    def test_consecutive_failures_open_circuit(self):
+        """After 3 consecutive failures, circuit should OPEN."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="failing_activity", args=())
+
+        for _ in range(3):
+            executor._update_circuit_breaker(activity, success=False)
+
+        circuit_key = executor._get_circuit_key(activity)
+        state = executor._circuit_breakers[circuit_key]
+
+        assert state.state == CircuitState.OPEN
+        assert state.failures == 3
+
+        allowed, status = executor._check_circuit_breaker(activity)
+        assert allowed is False
+        assert "OPEN" in status
+
+    def test_success_resets_failures_in_closed_state(self):
+        """Successful execution should reset failure counter in CLOSED state."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="flaky_activity", args=())
+
+        executor._update_circuit_breaker(activity, success=False)
+        executor._update_circuit_breaker(activity, success=False)
+
+        circuit_key = executor._get_circuit_key(activity)
+        state = executor._circuit_breakers[circuit_key]
+        assert state.failures == 2
+
+        executor._update_circuit_breaker(activity, success=True)
+
+        assert state.failures == 0
+        assert state.state == CircuitState.CLOSED
+
+    def test_half_open_state_after_timeout(self):
+        """After 60 seconds in OPEN state, circuit should transition to HALF_OPEN."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="recovering_activity", args=())
+
+        for _ in range(3):
+            executor._update_circuit_breaker(activity, success=False)
+
+        circuit_key = executor._get_circuit_key(activity)
+        state = executor._circuit_breakers[circuit_key]
+        state.state_changed_at = time.time() - 60.0
+
+        allowed, status = executor._check_circuit_breaker(activity)
+
+        assert allowed is True
+        assert "HALF_OPEN" in status
+        assert state.state == CircuitState.HALF_OPEN
+
+    def test_success_in_half_open_closes_circuit(self):
+        """Success in HALF_OPEN state should close the circuit."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="recovery_activity", args=())
+
+        for _ in range(3):
+            executor._update_circuit_breaker(activity, success=False)
+
+        circuit_key = executor._get_circuit_key(activity)
+        state = executor._circuit_breakers[circuit_key]
+        state.state = CircuitState.HALF_OPEN
+
+        executor._update_circuit_breaker(activity, success=True)
+
+        assert state.state == CircuitState.CLOSED
+        assert state.failures == 0
+
+    def test_failure_in_half_open_reopens_circuit(self):
+        """Failure in HALF_OPEN state should reopen the circuit."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="TestLib", activity="failing_recovery_activity", args=())
+
+        for _ in range(3):
+            executor._update_circuit_breaker(activity, success=False)
+
+        circuit_key = executor._get_circuit_key(activity)
+        state = executor._circuit_breakers[circuit_key]
+        state.state = CircuitState.HALF_OPEN
+
+        executor._update_circuit_breaker(activity, success=False)
+
+        assert state.state == CircuitState.OPEN
+
+    def test_circuit_breaker_isolation_per_activity(self):
+        """Circuit breakers should be isolated per activity."""
+        executor = ProcessExecutor()
+        activity1 = ActivityCall(library="Lib1", activity="act1", args=())
+        activity2 = ActivityCall(library="Lib2", activity="act2", args=())
+
+        executor._update_circuit_breaker(activity1, success=False)
+        executor._update_circuit_breaker(activity1, success=False)
+        executor._update_circuit_breaker(activity1, success=False)
+
+        executor._update_circuit_breaker(activity2, success=False)
+
+        state1 = executor._circuit_breakers[executor._get_circuit_key(activity1)]
+        state2 = executor._circuit_breakers[executor._get_circuit_key(activity2)]
+
+        assert state1.state == CircuitState.OPEN
+        assert state1.failures == 3
+        assert state2.state == CircuitState.CLOSED
+        assert state2.failures == 1
+
+    def test_no_circuit_breaker_for_nonexistent_activity(self):
+        """Activities without circuit breaker state should be allowed."""
+        executor = ProcessExecutor()
+        activity = ActivityCall(library="NonExistent", activity="missing", args=())
+
+        allowed, status = executor._check_circuit_breaker(activity)
+
+        assert allowed is True
+        assert status is None

--- a/packages/core/tests/test_circuit_breaker.py
+++ b/packages/core/tests/test_circuit_breaker.py
@@ -1,4 +1,5 @@
 """Tests for Circuit Breaker functionality in ProcessExecutor."""
+
 import time
 
 from rpaforge.core.execution import ActivityCall
@@ -48,7 +49,9 @@ class TestCircuitBreaker:
     def test_half_open_state_after_timeout(self):
         """After 60 seconds in OPEN state, circuit should transition to HALF_OPEN."""
         executor = ProcessExecutor()
-        activity = ActivityCall(library="TestLib", activity="recovering_activity", args=())
+        activity = ActivityCall(
+            library="TestLib", activity="recovering_activity", args=()
+        )
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
         circuit_key = executor._get_circuit_key(activity)
@@ -62,7 +65,9 @@ class TestCircuitBreaker:
     def test_success_in_half_open_closes_circuit(self):
         """Success in HALF_OPEN state should close the circuit."""
         executor = ProcessExecutor()
-        activity = ActivityCall(library="TestLib", activity="recovery_activity", args=())
+        activity = ActivityCall(
+            library="TestLib", activity="recovery_activity", args=()
+        )
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
         circuit_key = executor._get_circuit_key(activity)
@@ -75,7 +80,9 @@ class TestCircuitBreaker:
     def test_failure_in_half_open_reopens_circuit(self):
         """Failure in HALF_OPEN state should reopen the circuit."""
         executor = ProcessExecutor()
-        activity = ActivityCall(library="TestLib", activity="failing_recovery_activity", args=())
+        activity = ActivityCall(
+            library="TestLib", activity="failing_recovery_activity", args=()
+        )
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
         circuit_key = executor._get_circuit_key(activity)

--- a/packages/core/tests/test_circuit_breaker.py
+++ b/packages/core/tests/test_circuit_breaker.py
@@ -1,5 +1,4 @@
-: """Tests for Circuit Breaker functionality in ProcessExecutor."""
-
+"""Tests for Circuit Breaker functionality in ProcessExecutor."""
 import time
 
 from rpaforge.core.execution import ActivityCall
@@ -13,9 +12,7 @@ class TestCircuitBreaker:
         """Circuit breaker should start in CLOSED state."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="test_activity", args=())
-
         allowed, status = executor._check_circuit_breaker(activity)
-
         assert allowed is True
         assert status is None
         circuit_key = executor._get_circuit_key(activity)
@@ -25,16 +22,12 @@ class TestCircuitBreaker:
         """After 3 consecutive failures, circuit should OPEN."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="failing_activity", args=())
-
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
-
         circuit_key = executor._get_circuit_key(activity)
         state = executor._circuit_breakers[circuit_key]
-
         assert state.state == CircuitState.OPEN
         assert state.failures == 3
-
         allowed, status = executor._check_circuit_breaker(activity)
         assert allowed is False
         assert "OPEN" in status
@@ -43,16 +36,12 @@ class TestCircuitBreaker:
         """Successful execution should reset failure counter in CLOSED state."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="flaky_activity", args=())
-
         executor._update_circuit_breaker(activity, success=False)
         executor._update_circuit_breaker(activity, success=False)
-
         circuit_key = executor._get_circuit_key(activity)
         state = executor._circuit_breakers[circuit_key]
         assert state.failures == 2
-
         executor._update_circuit_breaker(activity, success=True)
-
         assert state.failures == 0
         assert state.state == CircuitState.CLOSED
 
@@ -60,16 +49,12 @@ class TestCircuitBreaker:
         """After 60 seconds in OPEN state, circuit should transition to HALF_OPEN."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="recovering_activity", args=())
-
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
-
         circuit_key = executor._get_circuit_key(activity)
         state = executor._circuit_breakers[circuit_key]
         state.state_changed_at = time.time() - 60.0
-
         allowed, status = executor._check_circuit_breaker(activity)
-
         assert allowed is True
         assert "HALF_OPEN" in status
         assert state.state == CircuitState.HALF_OPEN
@@ -78,16 +63,12 @@ class TestCircuitBreaker:
         """Success in HALF_OPEN state should close the circuit."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="recovery_activity", args=())
-
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
-
         circuit_key = executor._get_circuit_key(activity)
         state = executor._circuit_breakers[circuit_key]
         state.state = CircuitState.HALF_OPEN
-
         executor._update_circuit_breaker(activity, success=True)
-
         assert state.state == CircuitState.CLOSED
         assert state.failures == 0
 
@@ -95,16 +76,12 @@ class TestCircuitBreaker:
         """Failure in HALF_OPEN state should reopen the circuit."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="TestLib", activity="failing_recovery_activity", args=())
-
         for _ in range(3):
             executor._update_circuit_breaker(activity, success=False)
-
         circuit_key = executor._get_circuit_key(activity)
         state = executor._circuit_breakers[circuit_key]
         state.state = CircuitState.HALF_OPEN
-
         executor._update_circuit_breaker(activity, success=False)
-
         assert state.state == CircuitState.OPEN
 
     def test_circuit_breaker_isolation_per_activity(self):
@@ -112,16 +89,12 @@ class TestCircuitBreaker:
         executor = ProcessExecutor()
         activity1 = ActivityCall(library="Lib1", activity="act1", args=())
         activity2 = ActivityCall(library="Lib2", activity="act2", args=())
-
         executor._update_circuit_breaker(activity1, success=False)
         executor._update_circuit_breaker(activity1, success=False)
         executor._update_circuit_breaker(activity1, success=False)
-
         executor._update_circuit_breaker(activity2, success=False)
-
         state1 = executor._circuit_breakers[executor._get_circuit_key(activity1)]
         state2 = executor._circuit_breakers[executor._get_circuit_key(activity2)]
-
         assert state1.state == CircuitState.OPEN
         assert state1.failures == 3
         assert state2.state == CircuitState.CLOSED
@@ -131,8 +104,6 @@ class TestCircuitBreaker:
         """Activities without circuit breaker state should be allowed."""
         executor = ProcessExecutor()
         activity = ActivityCall(library="NonExistent", activity="missing", args=())
-
         allowed, status = executor._check_circuit_breaker(activity)
-
         assert allowed is True
         assert status is None


### PR DESCRIPTION
Implements circuit breaker pattern for activity retry logic to prevent
cascading failures when external services are down.

## Features
- Track consecutive failures per activity in execution state
- OPEN circuit after 3 consecutive failures, blocking retries
- HALF_OPEN state after 60s timeout to test service recovery  
- CLOSED state on successful execution
- Console notifications when circuit opens/closes

## Changes
- Added CircuitState enum and CircuitBreakerState dataclass
- Implemented _get_circuit_key, _check_circuit_breaker, _update_circuit_breaker methods
- Modified _run_activity to integrate circuit breaker with retry logic
- Added comprehensive unit tests

## Testing
- Unit tests cover all circuit breaker states and transitions
- Tests verify isolation per activity
- Integration with existing retry logic verified

Resolves #212

## Breaking Changes
None