### PR TITLE
perf(core): add LRU cache for AST expression parsing (fixes #209)

### DIFF
--- a/packages/core/src/rpaforge/core/safe_evaluator.py
+++ b/packages/core/src/rpaforge/core/safe_evaluator.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
 import ast
+import functools
 import keyword
 import operator
 from typing import Any
+
+DEFAULT_AST_CACHE_SIZE = 256
+
+
+@functools.lru_cache(maxsize=DEFAULT_AST_CACHE_SIZE)
+def _cached_parse_expression(condition: str) -> ast.Expression:
+    return ast.parse(condition, mode="eval")
+
 
 MAX_STRING_LENGTH = 10240
 MAX_LIST_LENGTH = 1000
@@ -258,7 +267,7 @@ def safe_eval(
             f"Expression length ({len(condition)}) exceeds maximum ({max_length})"
         )
     try:
-        tree = ast.parse(condition, mode="eval")
+        tree = _cached_parse_expression(condition)
         evaluator = SafeEvaluator(variables)
         result = evaluator.visit(tree.body)
         return bool(result)
@@ -289,3 +298,19 @@ class ConditionParser:
             return safe_eval(condition, self.variables)
         except Exception:
             return False
+
+
+def clear_expression_cache() -> None:
+    """Clear the AST parse cache."""
+    _cached_parse_expression.cache_clear()
+
+
+def get_cache_stats() -> dict[str, int]:
+    """Get AST parse cache statistics."""
+    stats = _cached_parse_expression.cache_info()
+    return {
+        "hits": stats.hits,
+        "misses": stats.misses,
+        "size": stats.currsize,
+        "maxsize": stats.maxsize,
+    }

--- a/packages/core/tests/test_safe_evaluator.py
+++ b/packages/core/tests/test_safe_evaluator.py
@@ -12,6 +12,8 @@ from rpaforge.core.safe_evaluator import (
     SAFE_OPERATORS,
     ConditionParser,
     SafeEvaluator,
+    clear_expression_cache,
+    get_cache_stats,
     safe_eval,
 )
 
@@ -942,3 +944,71 @@ class TestComplexExpressions:
         variables = {"age": 25, "has_license": True, "is_employed": True}
         result = safe_eval("(age >= 18 and has_license) or is_employed", variables)
         assert result is True
+
+
+class TestMemoization:
+    """Tests for AST parse memoization."""
+
+    def test_cache_clears_successfully(self):
+        """Test that cache can be cleared."""
+        clear_expression_cache()
+        stats = get_cache_stats()
+        assert stats["size"] == 0
+        assert stats["hits"] == 0
+        assert stats["misses"] == 0
+
+    def test_cache_misses_on_first_eval(self):
+        """Test cache miss on first evaluation."""
+        clear_expression_cache()
+        safe_eval("x > 5", {"x": 10})
+        stats = get_cache_stats()
+        assert stats["misses"] == 1
+        assert stats["hits"] == 0
+        assert stats["size"] == 1
+
+    def test_cache_hits_on_repeated_eval(self):
+        """Test cache hits on repeated same expression."""
+        clear_expression_cache()
+        safe_eval("x > 5", {"x": 10})
+        safe_eval("x > 5", {"x": 20})
+        safe_eval("x > 5", {"x": 30})
+        stats = get_cache_stats()
+        assert stats["hits"] == 2
+        assert stats["misses"] == 1
+        assert stats["size"] == 1
+
+    def test_different_expressions_different_cache_entries(self):
+        """Test that different expressions create separate cache entries."""
+        clear_expression_cache()
+        safe_eval("a > 5", {"a": 10})
+        safe_eval("b < 10", {"b": 5})
+        safe_eval("c == 3", {"c": 3})
+        stats = get_cache_stats()
+        assert stats["size"] == 3
+        assert stats["misses"] == 3
+        assert stats["hits"] == 0
+
+    def test_cache_respects_maxsize(self):
+        """Test that cache respects maxsize limit."""
+        clear_expression_cache()
+        for i in range(300):
+            safe_eval(f"x{i} > 5", {"x" + str(i): 10})
+        stats = get_cache_stats()
+        assert stats["maxsize"] == 256
+        assert stats["size"] <= 256
+
+    def test_cache_info_includes_maxsize(self):
+        """Test that cache info reports maxsize."""
+        clear_expression_cache()
+        stats = get_cache_stats()
+        assert "maxsize" in stats
+        assert stats["maxsize"] == 256
+
+    def test_cache_works_with_condition_parser(self):
+        """Test that ConditionParser also uses the cache."""
+        clear_expression_cache()
+        parser = ConditionParser({"x": 10})
+        parser.evaluate("x > 5")
+        parser.evaluate("x > 5")
+        stats = get_cache_stats()
+        assert stats["hits"] >= 1


### PR DESCRIPTION
## Summary
- Add LRU cache for AST parsing in `safe_evaluator.py` using `functools.lru_cache`
- Avoid re-parsing identical expressions during workflow execution
- Add `clear_expression_cache()` and `get_cache_stats()` utilities for cache management
- Add comprehensive `TestMemoization` test class with 7 test cases

## Changes
- `packages/core/src/rpaforge/core/safe_evaluator.py`: Added `_cached_parse_expression()` with `@lru_cache(maxsize=256)`
- `packages/core/tests/test_safe_evaluator.py`: Added `TestMemoization` class

## Performance Impact
Repeated condition evaluations now hit cache instead of re-parsing AST. Cache hit rate depends on workflow patterns (loop conditions, breakpoint conditions).

Closes #209