### PR TITLE
perf(studio): optimize React Flow canvas rendering (fixes #207)

### DIFF
--- a/packages/studio/src/components/Designer/ProcessCanvas.tsx
+++ b/packages/studio/src/components/Designer/ProcessCanvas.tsx
@@ -24,13 +24,14 @@ import { generateNodeId } from '../../utils/guid';
 import { createLogger } from '../../utils/logger';
 import { Activity } from '../../types/engine';
 import { validateConnection, createConnection, CONNECTION_STYLES } from '../../types/connections';
+import { useShallow } from 'zustand/shallow';
 import { useBlockStore, type ProcessNodeData } from '../../stores/blockStore';
 import { useHistoryStore } from '../../stores/historyStore';
 import { useSelectionStore } from '../../stores/selectionStore';
 import { useExecutionStore } from '../../stores/executionStore';
-import { useDebuggerStore } from '../../stores/debuggerStore';
 import { useDiagramStore } from '../../stores/diagramStore';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import { useThrottledCallback } from '../../hooks/useThrottledCallback';
 import CanvasToolbar, { type EdgeTypeOption } from './CanvasToolbar';
 import CanvasContextMenu from './CanvasContextMenu';
 import QuickAddActivity from './QuickAddActivity';
@@ -76,8 +77,8 @@ const ProcessCanvasInner: React.FC = () => {
     position: { x: 0, y: 0 },
   });
 
-  const storeNodes = useBlockStore((state) => state.nodes);
-  const storeEdges = useBlockStore((state) => state.edges);
+  const storeNodes = useBlockStore(useShallow((state) => state.nodes));
+  const storeEdges = useBlockStore(useShallow((state) => state.edges));
   const addNode = useBlockStore((state) => state.addNode);
   const addEdge = useBlockStore((state) => state.addEdge);
   const removeNode = useBlockStore((state) => state.removeNode);
@@ -98,12 +99,13 @@ const ProcessCanvasInner: React.FC = () => {
   const redoStack = useHistoryStore((state) => state.redoStack);
 
   const currentExecutingNodeId = useExecutionStore((state) => state.currentExecutingNodeId);
-
-  const {
-    breakpoints,
-    addBreakpoint,
-    removeBreakpoint,
-  } = useDebuggerStore();
+  const { breakpoints, addBreakpoint, removeBreakpoint } = useExecutionStore(
+    useShallow((state) => ({
+      breakpoints: state.breakpoints,
+      addBreakpoint: state.addBreakpoint,
+      removeBreakpoint: state.removeBreakpoint,
+    }))
+  );
   const openDiagram = useDiagramStore((state) => state.openDiagram);
 
   const [nodes, setNodes, onNodesChange] = useNodesState(storeNodes);
@@ -165,22 +167,23 @@ const ProcessCanvasInner: React.FC = () => {
     setContextMenu({ isOpen: false, position: { x: 0, y: 0 }, nodeId: null });
   }, []);
 
-  useEffect(() => {
-    // Merge store changes into ReactFlow state without replacing internal node state
-    // (positionAbsolute, selected, dragging) to prevent existing nodes from visually jumping.
-    setNodes((currentNodes) => {
+  const syncNodesToFlow = useCallback(
+    (currentNodes: Node<ProcessNodeData>[]) => {
       const currentMap = new Map(currentNodes.map((n) => [n.id, n]));
       return storeNodes.map((storeNode) => {
         const current = currentMap.get(storeNode.id);
         if (current) {
-          // Node already tracked by ReactFlow — preserve its internal state,
-          // only propagate data/type updates from the store.
           return { ...current, data: storeNode.data, type: storeNode.type };
         }
         return storeNode;
       });
-    });
-  }, [setNodes, storeNodes]);
+    },
+    [storeNodes]
+  );
+
+  useEffect(() => {
+    setNodes(syncNodesToFlow);
+  }, [setNodes, syncNodesToFlow]);
 
   useEffect(() => {
     setEdges(storeEdges.map(ed => ({ ...ed, type: edgeType })));
@@ -484,11 +487,16 @@ const ProcessCanvasInner: React.FC = () => {
     (changes: NodeChange[]) => {
       onNodesChange(changes);
 
-      changes.forEach((change) => {
-        if (change.type === 'position' && change.position && change.dragging === false) {
+      const debouncedUpdates = changes.filter(
+        (c) => c.type === 'position' && c.position && c.dragging === false
+      );
+      debouncedUpdates.forEach((change) => {
+        if (change.type === 'position' && change.position) {
           updateNodePosition(change.id, change.position);
         }
+      });
 
+      changes.forEach((change) => {
         if (change.type === 'remove') {
           removeNode(change.id);
         }
@@ -511,6 +519,9 @@ const ProcessCanvasInner: React.FC = () => {
     },
     [removeEdge]
   );
+
+  const throttledNodesChange = useThrottledCallback(handleNodesChange, 16);
+  const throttledEdgesChange = useThrottledCallback(handleEdgesChange, 16);
 
   return (
     <div 
@@ -544,8 +555,8 @@ const ProcessCanvasInner: React.FC = () => {
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodesChange={handleNodesChange}
-        onEdgesChange={handleEdgesChange}
+        onNodesChange={throttledNodesChange}
+        onEdgesChange={throttledEdgesChange}
         onEdgeUpdate={(oldEdge, newConnection) => {
           updateEdge(oldEdge.id, {
             source: newConnection.source,

--- a/packages/studio/src/hooks/useThrottledCallback.ts
+++ b/packages/studio/src/hooks/useThrottledCallback.ts
@@ -1,0 +1,38 @@
+import { useCallback, useRef } from 'react';
+
+export function useThrottledCallback<T extends (...args: never[]) => void>(
+  callback: T,
+  delay: number
+): T {
+  const lastCall = useRef<number>(0);
+  const pendingArgs = useRef<Parameters<T> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const throttled = useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now();
+      const timeSinceLastCall = now - lastCall.current;
+
+      if (timeSinceLastCall >= delay) {
+        lastCall.current = now;
+        callback(...args);
+      } else {
+        pendingArgs.current = args;
+
+        if (!timeoutRef.current) {
+          timeoutRef.current = setTimeout(() => {
+            if (pendingArgs.current) {
+              lastCall.current = Date.now();
+              callback(...pendingArgs.current);
+              pendingArgs.current = null;
+            }
+            timeoutRef.current = null;
+          }, delay - timeSinceLastCall);
+        }
+      }
+    },
+    [callback, delay]
+  ) as unknown as T;
+
+  return throttled;
+}

--- a/packages/studio/src/stores/debuggerStore.ts
+++ b/packages/studio/src/stores/debuggerStore.ts
@@ -7,6 +7,7 @@
 
 import { create } from 'zustand';
 import type { Breakpoint, Variable, CallFrame } from '../types/engine';
+import { useExecutionStore } from './executionStore';
 
 export type DebuggerConnectionState = 'disconnected' | 'connecting' | 'connected';
 
@@ -57,7 +58,7 @@ interface DebuggerState {
   reset: () => void;
 }
 
-export const useDebuggerStore = create<DebuggerState>((set, get) => ({
+export const useDebuggerStore = create<DebuggerState>((set) => ({
   connectionState: 'disconnected',
 
   breakpoints: new Map(),
@@ -78,6 +79,7 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   setConnectionState: (state) => set({ connectionState: state }),
 
   addBreakpoint: (breakpoint) => {
+    useExecutionStore.getState().addBreakpoint(breakpoint);
     set((state) => {
       const newBreakpoints = new Map(state.breakpoints);
       newBreakpoints.set(breakpoint.id, breakpoint);
@@ -94,6 +96,7 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   },
 
   removeBreakpoint: (id) => {
+    useExecutionStore.getState().removeBreakpoint(id);
     set((state) => {
       const breakpoint = state.breakpoints.get(id);
       if (!breakpoint) return state;
@@ -118,6 +121,7 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   },
 
   toggleBreakpoint: (id) => {
+    useExecutionStore.getState().toggleBreakpoint(id);
     set((state) => {
       const breakpoint = state.breakpoints.get(id);
       if (!breakpoint) return state;
@@ -130,6 +134,7 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   },
 
   updateBreakpoint: (id, updates) => {
+    useExecutionStore.getState().updateBreakpoint(id, updates);
     set((state) => {
       const breakpoint = state.breakpoints.get(id);
       if (!breakpoint) return state;
@@ -142,6 +147,7 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   },
 
   clearBreakpoints: (file) => {
+    useExecutionStore.getState().clearBreakpoints(file);
     set((state) => {
       if (file) {
         const fileBpIds = state.fileBreakpoints.get(file) || [];
@@ -165,14 +171,11 @@ export const useDebuggerStore = create<DebuggerState>((set, get) => ({
   },
 
   getBreakpointsForFile: (file) => {
-    const state = get();
-    const bpIds = state.fileBreakpoints.get(file) || [];
-    return bpIds
-      .map((id) => state.breakpoints.get(id))
-      .filter((bp): bp is Breakpoint => bp !== undefined);
+    return useExecutionStore.getState().getBreakpointsForFile(file);
   },
 
   cleanupStaleBreakpoints: (validNodeIds) => {
+    useExecutionStore.getState().cleanupStaleBreakpoints(validNodeIds);
     set((state) => {
       const newBreakpoints = new Map<string, Breakpoint>();
       const newFileBreakpoints = new Map<string, string[]>();

--- a/packages/studio/src/stores/executionStore.ts
+++ b/packages/studio/src/stores/executionStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { Breakpoint } from '../types/engine';
 
 export type ExecutionState = 'idle' | 'running' | 'paused' | 'stopped';
 export type ExecutionSpeed = 0.5 | 1 | 2 | 5;
@@ -9,18 +10,35 @@ interface ExecutionStateData {
   currentExecutingNodeId: string | null;
   executionSpeed: ExecutionSpeed;
 
+  // Breakpoint state (migrated from debuggerStore)
+  breakpoints: Map<string, Breakpoint>;
+  fileBreakpoints: Map<string, string[]>;
+
   setExecutionState: (state: ExecutionState) => void;
   setExecutionProgress: (progress: number) => void;
   setCurrentExecutingNode: (id: string | null) => void;
   setExecutionSpeed: (speed: ExecutionSpeed) => void;
   resetExecution: () => void;
+
+  // Breakpoint methods
+  addBreakpoint: (breakpoint: Breakpoint) => void;
+  removeBreakpoint: (id: string) => void;
+  toggleBreakpoint: (id: string) => void;
+  updateBreakpoint: (id: string, updates: Partial<Breakpoint>) => void;
+  clearBreakpoints: (file?: string) => void;
+  getBreakpointsForFile: (file: string) => Breakpoint[];
+  cleanupStaleBreakpoints: (validNodeIds: Set<string>) => void;
 }
 
-export const useExecutionStore = create<ExecutionStateData>((set) => ({
+export const useExecutionStore = create<ExecutionStateData>((set, get) => ({
   executionState: 'idle',
   executionProgress: 0,
   currentExecutingNodeId: null,
   executionSpeed: 1,
+
+  // Breakpoint state
+  breakpoints: new Map(),
+  fileBreakpoints: new Map(),
 
   setExecutionState: (state) => set({ executionState: state }),
 
@@ -36,4 +54,120 @@ export const useExecutionStore = create<ExecutionStateData>((set) => ({
       executionProgress: 0,
       currentExecutingNodeId: null,
     }),
+
+  // Breakpoint methods
+  addBreakpoint: (breakpoint) => {
+    set((state) => {
+      const newBreakpoints = new Map(state.breakpoints);
+      newBreakpoints.set(breakpoint.id, breakpoint);
+
+      const newFileBreakpoints = new Map(state.fileBreakpoints);
+      const fileBps = newFileBreakpoints.get(breakpoint.file) || [];
+      newFileBreakpoints.set(breakpoint.file, [...fileBps, breakpoint.id]);
+
+      return {
+        breakpoints: newBreakpoints,
+        fileBreakpoints: newFileBreakpoints,
+      };
+    });
+  },
+
+  removeBreakpoint: (id) => {
+    set((state) => {
+      const breakpoint = state.breakpoints.get(id);
+      if (!breakpoint) return state;
+
+      const newBreakpoints = new Map(state.breakpoints);
+      newBreakpoints.delete(id);
+
+      const newFileBreakpoints = new Map(state.fileBreakpoints);
+      const fileBps = newFileBreakpoints.get(breakpoint.file);
+      if (fileBps) {
+        newFileBreakpoints.set(
+          breakpoint.file,
+          fileBps.filter((bpId) => bpId !== id)
+        );
+      }
+
+      return {
+        breakpoints: newBreakpoints,
+        fileBreakpoints: newFileBreakpoints,
+      };
+    });
+  },
+
+  toggleBreakpoint: (id) => {
+    set((state) => {
+      const breakpoint = state.breakpoints.get(id);
+      if (!breakpoint) return state;
+
+      const newBreakpoints = new Map(state.breakpoints);
+      newBreakpoints.set(id, { ...breakpoint, enabled: !breakpoint.enabled });
+
+      return { breakpoints: newBreakpoints };
+    });
+  },
+
+  updateBreakpoint: (id, updates) => {
+    set((state) => {
+      const breakpoint = state.breakpoints.get(id);
+      if (!breakpoint) return state;
+
+      const newBreakpoints = new Map(state.breakpoints);
+      newBreakpoints.set(id, { ...breakpoint, ...updates });
+
+      return { breakpoints: newBreakpoints };
+    });
+  },
+
+  clearBreakpoints: (file) => {
+    set((state) => {
+      if (file) {
+        const fileBpIds = state.fileBreakpoints.get(file) || [];
+        const newBreakpoints = new Map(state.breakpoints);
+        fileBpIds.forEach((id) => newBreakpoints.delete(id));
+
+        const newFileBreakpoints = new Map(state.fileBreakpoints);
+        newFileBreakpoints.delete(file);
+
+        return {
+          breakpoints: newBreakpoints,
+          fileBreakpoints: newFileBreakpoints,
+        };
+      }
+
+      return {
+        breakpoints: new Map(),
+        fileBreakpoints: new Map(),
+      };
+    });
+  },
+
+  getBreakpointsForFile: (file) => {
+    const state = get();
+    const bpIds = state.fileBreakpoints.get(file) || [];
+    return bpIds
+      .map((id) => state.breakpoints.get(id))
+      .filter((bp): bp is Breakpoint => bp !== undefined);
+  },
+
+  cleanupStaleBreakpoints: (validNodeIds) => {
+    set((state) => {
+      const newBreakpoints = new Map<string, Breakpoint>();
+      const newFileBreakpoints = new Map<string, string[]>();
+
+      for (const [id, bp] of state.breakpoints) {
+        if (validNodeIds.has(bp.file)) {
+          newBreakpoints.set(id, bp);
+          const fileBps = newFileBreakpoints.get(bp.file) || [];
+          newFileBreakpoints.set(bp.file, [...fileBps, id]);
+        }
+      }
+
+      return {
+        breakpoints: newBreakpoints,
+        fileBreakpoints: newFileBreakpoints,
+      };
+    });
+  },
 }));


### PR DESCRIPTION
## Summary
- Merge debuggerStore breakpoints into executionStore
- Add useShallow selectors to prevent re-renders
- Add 16ms throttling for node/edge change handlers
- Create useThrottledCallback hook
- Fix dual-state sync effect

## Performance Impact
- Reduces re-renders during pan/zoom operations
- Prevents unnecessary state updates with shallow comparison
- Throttles handlers to reduce React Flow update frequency

Closes #207