### PR TITLE
fix(codeql): resolve all open CodeQL scanning alerts

### DIFF
--- a/packages/core/src/rpaforge/bridge/server.py
+++ b/packages/core/src/rpaforge/bridge/server.py
@@ -109,7 +109,7 @@ class BridgeServer:
         try:
             await self._read_loop()
         except asyncio.CancelledError:
-            pass
+            pass  # normal shutdown — cancellation is not an error
         finally:
             self._teardown_logging()
             self._running = False

--- a/packages/core/src/rpaforge/core/checkpoint.py
+++ b/packages/core/src/rpaforge/core/checkpoint.py
@@ -14,10 +14,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from rpaforge.core.runner import Breakpoint, CallFrame
+from rpaforge.core.models import Breakpoint, CallFrame
 
 logger = logging.getLogger("rpaforge")
 

--- a/packages/core/src/rpaforge/core/diagram_converter.py
+++ b/packages/core/src/rpaforge/core/diagram_converter.py
@@ -6,6 +6,7 @@ Converts visual diagram JSON to Process objects for execution.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from rpaforge.core.execution import ActivityCall, Process, Task
@@ -15,6 +16,8 @@ from rpaforge.core.validator import (
 from rpaforge.core.validator import (
     ValidationError as DiagramValidationError,
 )
+
+logger = logging.getLogger("rpaforge.converter")
 
 
 class DiagramConverter:
@@ -98,8 +101,10 @@ class DiagramConverter:
                     try:
                         validated_name = validate_variable_name(var_name)
                         variables[validated_name] = expr
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(
+                            "Skipping invalid variable name %r: %s", var_name, e
+                        )
 
         return variables
 

--- a/packages/core/src/rpaforge/core/models.py
+++ b/packages/core/src/rpaforge/core/models.py
@@ -1,0 +1,35 @@
+"""
+RPAForge debug model types.
+
+Pure data classes shared between runner and checkpoint modules to avoid
+cyclic imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Breakpoint:
+    """A breakpoint in execution."""
+
+    id: str
+    node_id: str
+    line: int = 0
+    enabled: bool = True
+    condition: str | None = None
+    hit_count: int = 0
+    hit_condition: str | None = None
+
+
+@dataclass
+class CallFrame:
+    """Call stack frame."""
+
+    activity: str
+    library: str
+    line: int
+    args: tuple[Any, ...]
+    node_id: str = ""

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
-from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -20,6 +19,7 @@ from rpaforge.core.execution import (
 )
 from rpaforge.core.executor import ProcessExecutor, StopExecution
 from rpaforge.core.interfaces import Executor
+from rpaforge.core.models import Breakpoint, CallFrame
 from rpaforge.core.safe_evaluator import safe_eval
 from rpaforge.core.validator import (
     ValidationError as ProcessValidationError,
@@ -40,30 +40,6 @@ class RunnerState(Enum):
     PAUSED = "paused"
     CANCELLING = "cancelling"
     STOPPED = "stopped"
-
-
-@dataclass
-class Breakpoint:
-    """A breakpoint in execution."""
-
-    id: str
-    node_id: str
-    line: int = 0
-    enabled: bool = True
-    condition: str | None = None
-    hit_count: int = 0
-    hit_condition: str | None = None
-
-
-@dataclass
-class CallFrame:
-    """Call stack frame."""
-
-    activity: str
-    library: str
-    line: int
-    args: tuple[Any, ...]
-    node_id: str = ""
 
 
 class ProcessRunner:

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from rpaforge.core.checkpoint import CheckpointManager
 from rpaforge.core.execution import (
     ActivityCall,
     ExecutionResult,
@@ -30,7 +29,7 @@ from rpaforge.core.validator import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from rpaforge.core.checkpoint import CheckpointManager
 
 logger = logging.getLogger("rpaforge")
 
@@ -76,6 +75,8 @@ class ProcessRunner:
         checkpoint_manager: CheckpointManager | None = None,
         checkpoint_frequency: int = 10,
     ):
+        from rpaforge.core.checkpoint import CheckpointManager
+
         self._executor: Executor = executor or ProcessExecutor()
         self._checkpoint_manager = checkpoint_manager or CheckpointManager(
             frequency=checkpoint_frequency

--- a/packages/core/src/rpaforge/core/subprocess_executor.py
+++ b/packages/core/src/rpaforge/core/subprocess_executor.py
@@ -115,20 +115,17 @@ class SubprocessExecutor:
             raise RuntimeError("Executor is closed")
 
         if timeout_ms <= 0:
-            timeout_seconds = None
-        else:
-            timeout_seconds = timeout_ms / 1000.0
-            pool = self._get_pool()
-            async_result = pool.apply_async(
-                self._execute_in_subprocess,
-                (library_path, activity_name, args, kwargs),
+            return self._execute_in_subprocess(
+                library_path, activity_name, args, kwargs
             )
 
+        timeout_seconds = timeout_ms / 1000.0
+        pool = self._get_pool()
+        async_result = pool.apply_async(
+            self._execute_in_subprocess,
+            (library_path, activity_name, args, kwargs),
+        )
         try:
-            if timeout_seconds is None:
-                return self._execute_in_subprocess(
-                    library_path, activity_name, args, kwargs
-                )
             return async_result.get(timeout=timeout_seconds)
         except multiprocessing.TimeoutError as err:
             self._kill_child_processes()

--- a/packages/core/src/rpaforge/core/validator.py
+++ b/packages/core/src/rpaforge/core/validator.py
@@ -269,7 +269,7 @@ class ProcessValidator:
             block_type = block_data.get("type", "")
 
             successors = edge_map.get(node_id, [])
-            if not successors:
+            if not successors and block_type not in ("while", "for-each"):
                 continue
 
             if block_type == "if":


### PR DESCRIPTION
## Summary

- **subprocess_executor.py** — eliminate uninitialized `pool`/`async_result` via early return before timeout path (`py/uninitialized-local-variable`)
- **validator.py** — fix unreachable `while`/`for-each` empty-body checks by tightening outer `continue` condition (`py/unreachable-statement`)
- **runner.py** — break cyclic import with `checkpoint.py` via lazy import inside `__init__`, keep `TYPE_CHECKING` guard for type hints (`py/unsafe-cyclic-import`)
- **diagram_converter.py** — replace bare `except: pass` with `logger.debug(...)` (`py/empty-except`)
- **server.py** — document intentional `CancelledError` suppression as normal shutdown path (`py/empty-except`)

## Test plan

- [x] All 376 existing Python tests pass (`pytest packages/core/tests/ -q`)
- [x] `ruff check` passes on all 5 modified files
- [x] No new lint errors introduced