### PR TITLE
security: resolve ruff executable path via shutil.which()

### DIFF
--- a/packages/core/src/rpaforge/bridge/handlers.py
+++ b/packages/core/src/rpaforge/bridge/handlers.py
@@ -12,9 +12,6 @@ import json
 import shutil
 import time
 from typing import TYPE_CHECKING, Any
-
-_RUFF_EXECUTABLE: str | None = shutil.which("ruff")
-
 from rpaforge.bridge.events import (
     ErrorEvent,
     LogEvent,
@@ -26,6 +23,8 @@ from rpaforge.bridge.events import (
 )
 from rpaforge.bridge.protocol import JSONRPCError, JSONRPCErrorCode
 from rpaforge.core.activity import list_activities, list_libraries
+
+_RUFF_EXECUTABLE: str | None = shutil.which("ruff")
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/packages/core/src/rpaforge/bridge/handlers.py
+++ b/packages/core/src/rpaforge/bridge/handlers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import shutil
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -943,8 +944,12 @@ class BridgeHandlers:
                 f.write(code)
                 temp_path = f.name
 
+            ruff_path = shutil.which("ruff")
+            if not ruff_path:
+                raise FileNotFoundError("ruff not found")
+
             result = subprocess.run(
-                ["ruff", "format", temp_path],
+                [ruff_path, "format", temp_path],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -1044,8 +1049,12 @@ class BridgeHandlers:
                 f.write(code)
                 temp_path = f.name
 
+            ruff_path = shutil.which("ruff")
+            if not ruff_path:
+                raise FileNotFoundError("ruff not found")
+
             result = subprocess.run(
-                ["ruff", "check", temp_path, "--output-format=json"],
+                [ruff_path, "check", temp_path, "--output-format=json"],
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/packages/core/src/rpaforge/bridge/handlers.py
+++ b/packages/core/src/rpaforge/bridge/handlers.py
@@ -12,6 +12,7 @@ import json
 import shutil
 import time
 from typing import TYPE_CHECKING, Any
+
 from rpaforge.bridge.events import (
     ErrorEvent,
     LogEvent,

--- a/packages/core/src/rpaforge/bridge/handlers.py
+++ b/packages/core/src/rpaforge/bridge/handlers.py
@@ -13,6 +13,8 @@ import shutil
 import time
 from typing import TYPE_CHECKING, Any
 
+_RUFF_EXECUTABLE: str | None = shutil.which("ruff")
+
 from rpaforge.bridge.events import (
     ErrorEvent,
     LogEvent,
@@ -944,12 +946,14 @@ class BridgeHandlers:
                 f.write(code)
                 temp_path = f.name
 
-            ruff_path = shutil.which("ruff")
-            if not ruff_path:
-                raise FileNotFoundError("ruff not found")
+            if _RUFF_EXECUTABLE is None:
+                raise JSONRPCError(
+                    code=JSONRPCErrorCode.INTERNAL_ERROR,
+                    message="ruff is not installed or not found in PATH",
+                )
 
             result = subprocess.run(
-                [ruff_path, "format", temp_path],
+                [_RUFF_EXECUTABLE, "format", temp_path],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -1049,12 +1053,14 @@ class BridgeHandlers:
                 f.write(code)
                 temp_path = f.name
 
-            ruff_path = shutil.which("ruff")
-            if not ruff_path:
-                raise FileNotFoundError("ruff not found")
+            if _RUFF_EXECUTABLE is None:
+                raise JSONRPCError(
+                    code=JSONRPCErrorCode.INTERNAL_ERROR,
+                    message="ruff is not installed or not found in PATH",
+                )
 
             result = subprocess.run(
-                [ruff_path, "check", temp_path, "--output-format=json"],
+                [_RUFF_EXECUTABLE, "check", temp_path, "--output-format=json"],
                 capture_output=True,
                 text=True,
                 timeout=10,


### PR DESCRIPTION
This PR resolves issue #299 by using shutil.which() to resolve the absolute path of the ruff executable, preventing potential PATH hijacking.