### PR TITLE
feat(studio): добавить ID запуска к логам консоли (#296)

### DIFF
--- a/packages/core/src/rpaforge/bridge/events.py
+++ b/packages/core/src/rpaforge/bridge/events.py
@@ -51,6 +51,7 @@ class LogEvent(BridgeEvent):
     level: str = "info"
     message: str = ""
     source: str | None = None
+    run_id: str = ""
 
     @classmethod
     def event_type(cls) -> str:
@@ -62,6 +63,7 @@ class LogEvent(BridgeEvent):
             {
                 "level": self.level,
                 "message": self.message,
+                "runId": self.run_id,
             }
         )
         if self.source:
@@ -102,6 +104,7 @@ class ProcessStartedEvent(BridgeEvent):
 
     process_id: str = ""
     name: str = ""
+    run_id: str = ""
 
     @classmethod
     def event_type(cls) -> str:
@@ -113,6 +116,7 @@ class ProcessStartedEvent(BridgeEvent):
             {
                 "processId": self.process_id,
                 "name": self.name,
+                "runId": self.run_id,
             }
         )
         return result

--- a/packages/core/src/rpaforge/bridge/handlers.py
+++ b/packages/core/src/rpaforge/bridge/handlers.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import shutil
 import time
+import uuid
 from typing import TYPE_CHECKING, Any
 
 from rpaforge.bridge.events import (
@@ -56,6 +57,7 @@ class BridgeHandlers:
         self._last_heartbeat: float = time.time()
         self._lifecycle_lock = asyncio.Lock()
         self._pending_breakpoints: list[dict[str, Any]] = []
+        self._current_run_id: str = ""
         self._ensure_activities_registered()
 
     def _ensure_activities_registered(self) -> None:
@@ -167,6 +169,7 @@ class BridgeHandlers:
                 LogEvent(
                     level="info",
                     message="Process cancellation requested",
+                    run_id=self._current_run_id,
                 ).to_dict()
             )
 
@@ -257,11 +260,13 @@ class BridgeHandlers:
             self._cancel_requested = False
             self._paused = False
             self._terminal_event_emitted = False
+            self._current_run_id = str(uuid.uuid4())
 
             self._emit(
                 ProcessStartedEvent(
                     process_id=self._process_id,
                     name=params.get("name", "Unnamed"),
+                    run_id=self._current_run_id,
                 ).to_dict()
             )
 
@@ -269,6 +274,7 @@ class BridgeHandlers:
                 LogEvent(
                     level="info",
                     message=f"Starting process: {self._process_id}",
+                    run_id=self._current_run_id,
                 ).to_dict()
             )
 
@@ -347,11 +353,13 @@ class BridgeHandlers:
             self._cancel_requested = False
             self._paused = False
             self._terminal_event_emitted = False
+            self._current_run_id = str(uuid.uuid4())
 
             self._emit(
                 ProcessStartedEvent(
                     process_id=self._process_id,
                     name=process.name,
+                    run_id=self._current_run_id,
                 ).to_dict()
             )
 
@@ -359,6 +367,7 @@ class BridgeHandlers:
                 LogEvent(
                     level="info",
                     message=f"Starting process: {self._process_id}",
+                    run_id=self._current_run_id,
                 ).to_dict()
             )
 
@@ -426,6 +435,7 @@ class BridgeHandlers:
             LogEvent(
                 level="info",
                 message=message,
+                run_id=self._current_run_id,
             ).to_dict()
         )
 
@@ -1248,6 +1258,7 @@ class BridgeHandlers:
             LogEvent(
                 level="info",
                 message=f"Bridge shutdown initiated: {reason}",
+                run_id=self._current_run_id,
             ).to_dict()
         )
 

--- a/packages/studio/src/components/Debugger/ConsoleOutput.tsx
+++ b/packages/studio/src/components/Debugger/ConsoleOutput.tsx
@@ -10,6 +10,7 @@ import {
   FiFile,
   FiExternalLink,
   FiMessageSquare,
+  FiLayers,
 } from 'react-icons/fi';
 import { useTranslation } from 'react-i18next';
 import { useConsoleStore, type LogEntry } from '../../stores/consoleStore';
@@ -278,6 +279,17 @@ const LogLine: React.FC<{ entry: LogEntry; index: number }> = ({ entry, index })
   );
 };
 
+function RunSeparator({ runNumber, timestamp }: { runNumber: number; timestamp: Date }) {
+  const timeStr = timestamp.toLocaleTimeString();
+  return (
+    <div className="flex items-center gap-2 px-3 py-1 text-xs text-slate-400 dark:text-slate-500 select-none">
+      <div className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+      <span>── Run #{runNumber} started at {timeStr} ──</span>
+      <div className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+    </div>
+  );
+}
+
 const ConsoleOutput: React.FC = () => {
   const { t } = useTranslation('common');
   const logs = useConsoleStore((state) => state.logs);
@@ -289,6 +301,8 @@ const ConsoleOutput: React.FC = () => {
   const setSearchQuery = useConsoleStore((state) => state.setSearchQuery);
   const setAutoScroll = useConsoleStore((state) => state.setAutoScroll);
   const exportLogs = useConsoleStore((state) => state.exportLogs);
+  const showCurrentRunOnly = useConsoleStore((state) => state.showCurrentRunOnly);
+  const setShowCurrentRunOnly = useConsoleStore((state) => state.setShowCurrentRunOnly);
 
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -304,8 +318,26 @@ const ConsoleOutput: React.FC = () => {
       );
     }
 
+    if (showCurrentRunOnly) {
+      const currentRunId = logs.filter((l) => l.runId).at(-1)?.runId;
+      if (currentRunId) {
+        filtered = filtered.filter((log) => log.runId === currentRunId);
+      }
+    }
+
     return filtered;
-  }, [logs, filter, searchQuery]);
+  }, [logs, filter, searchQuery, showCurrentRunOnly]);
+
+  const runNumberMap = useMemo(() => {
+    const map = new Map<string, number>();
+    let counter = 0;
+    for (const log of logs) {
+      if (log.runId && !map.has(log.runId)) {
+        map.set(log.runId, ++counter);
+      }
+    }
+    return map;
+  }, [logs]);
 
   useEffect(() => {
     if (autoScroll && containerRef.current) {
@@ -359,6 +391,18 @@ const ConsoleOutput: React.FC = () => {
 
         <div className="flex items-center gap-1 flex-shrink-0">
           <button
+            onClick={() => setShowCurrentRunOnly(!showCurrentRunOnly)}
+            className={`flex items-center gap-1 px-2 py-1 text-xs rounded transition-colors ${
+              showCurrentRunOnly
+                ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+            }`}
+            title="Show current run only"
+          >
+            <FiLayers className="w-3 h-3" />
+            <span>{showCurrentRunOnly ? 'Current run' : 'All runs'}</span>
+          </button>
+          <button
             className={`p-1.5 rounded hover:bg-slate-200 dark:hover:bg-slate-700 ${
               autoScroll ? 'text-indigo-500' : 'text-slate-400'
             }`}
@@ -397,7 +441,21 @@ const ConsoleOutput: React.FC = () => {
             )}
           </div>
         ) : (
-          filteredLogs.map((entry, index) => <LogLine key={entry.id} entry={entry} index={index} />)
+          filteredLogs.map((entry, index) => {
+            const prevEntry = filteredLogs[index - 1];
+            const showSeparator = entry.runId && (!prevEntry || prevEntry.runId !== entry.runId);
+            return (
+              <React.Fragment key={entry.id}>
+                {showSeparator && (
+                  <RunSeparator
+                    runNumber={runNumberMap.get(entry.runId!) ?? 1}
+                    timestamp={entry.timestamp}
+                  />
+                )}
+                <LogLine entry={entry} index={index} />
+              </React.Fragment>
+            );
+          })
         )}
       </div>
 

--- a/packages/studio/src/hooks/useEngine.ts
+++ b/packages/studio/src/hooks/useEngine.ts
@@ -182,14 +182,16 @@ export const useEngine = (): UseEngineResult => {
         setIsRunning(true);
         setIsPaused(false);
         setExecutionState('running');
-        
-        const startEvent = event as { processName?: string };
+
+        const startEvent = event as { processName?: string; runId?: string };
         const processName = startEvent.processName || useProcessMetadataStore.getState().metadata?.name || 'Unknown Process';
         currentExecutionIdRef.current = startExecution(processName);
-        
+        useConsoleStore.getState().setCurrentRunId(startEvent.runId ?? null);
+
         addConsoleLog({
           level: 'info',
           message: 'Process execution started',
+          runId: startEvent.runId,
         });
       })
     );
@@ -215,6 +217,7 @@ export const useEngine = (): UseEngineResult => {
         addConsoleLog({
           level: 'info',
           message: 'Process execution finished',
+          runId: useConsoleStore.getState().currentRunId ?? undefined,
         });
       })
     );
@@ -313,10 +316,12 @@ export const useEngine = (): UseEngineResult => {
 
     unsubscribers.push(
       bridgeRef.current.onEvent('log', (event) => {
-        const logEvent = event as { level?: string; message: string };
+        const logEvent = event as { level?: string; message?: string; source?: string; runId?: string };
         addConsoleLog({
           level: (logEvent.level as 'info' | 'warn' | 'error' | 'debug') || 'info',
-          message: logEvent.message,
+          message: logEvent.message ?? '',
+          source: logEvent.source,
+          runId: logEvent.runId,
         });
       })
     );

--- a/packages/studio/src/stores/consoleStore.ts
+++ b/packages/studio/src/stores/consoleStore.ts
@@ -14,6 +14,7 @@ export interface LogEntry {
   level: LogLevel;
   message: string;
   source?: string;
+  runId?: string;
   details?: unknown;
 }
 
@@ -23,6 +24,8 @@ interface ConsoleState {
   searchQuery: string;
   autoScroll: boolean;
   maxLogs: number;
+  currentRunId: string | null;
+  showCurrentRunOnly: boolean;
 
   addLog: (entry: Omit<LogEntry, 'id' | 'timestamp'>) => void;
   addLogs: (entries: Omit<LogEntry, 'id' | 'timestamp'>[]) => void;
@@ -32,6 +35,8 @@ interface ConsoleState {
   toggleFilterLevel: (level: LogLevel) => void;
   setSearchQuery: (query: string) => void;
   setAutoScroll: (autoScroll: boolean) => void;
+  setCurrentRunId: (runId: string | null) => void;
+  setShowCurrentRunOnly: (show: boolean) => void;
 
   getFilteredLogs: () => LogEntry[];
   exportLogs: () => string;
@@ -47,6 +52,8 @@ export const useConsoleStore = create<ConsoleState>((set, get) => ({
   searchQuery: '',
   autoScroll: true,
   maxLogs: config.console.maxLogs,
+  currentRunId: null,
+  showCurrentRunOnly: false,
 
   addLog: (entry) => {
     const log: LogEntry = {
@@ -110,8 +117,12 @@ export const useConsoleStore = create<ConsoleState>((set, get) => ({
 
   setAutoScroll: (autoScroll) => set({ autoScroll }),
 
+  setCurrentRunId: (runId) => set({ currentRunId: runId }),
+
+  setShowCurrentRunOnly: (show) => set({ showCurrentRunOnly: show }),
+
   getFilteredLogs: () => {
-    const { logs, filter, searchQuery } = get();
+    const { logs, filter, searchQuery, showCurrentRunOnly, currentRunId } = get();
 
     let filtered = logs.filter((log) => filter.includes(log.level));
 
@@ -122,6 +133,10 @@ export const useConsoleStore = create<ConsoleState>((set, get) => ({
           log.message.toLowerCase().includes(query) ||
           log.source?.toLowerCase().includes(query)
       );
+    }
+
+    if (showCurrentRunOnly && currentRunId) {
+      filtered = filtered.filter((log) => log.runId === currentRunId);
     }
 
     return filtered;

--- a/packages/studio/src/types/events.ts
+++ b/packages/studio/src/types/events.ts
@@ -48,6 +48,7 @@ export interface LogEvent {
   level: LogLevel;
   message: string;
   source?: string;
+  runId?: string;
 }
 
 export interface BreakpointHitEvent {


### PR DESCRIPTION
## Summary

- Каждый запуск процесса получает уникальный `runId` (UUID), генерируемый на Python-стороне в `handlers.py`
- Визуальные разделители `── Run #N started at HH:MM:SS ──` между запусками в консоли
- Кнопка "All runs / Current run" в тулбаре для фильтрации по текущему запуску

## Changes

- `events.py` — `LogEvent` и `ProcessStartedEvent` передают `runId`
- `handlers.py` — генерация UUID при старте, передача во все `LogEvent`
- `consoleStore.ts` — `runId` в `LogEntry`, стейт `currentRunId`/`showCurrentRunOnly`
- `useEngine.ts` — проброс `runId` из событий моста в стор
- `ConsoleOutput.tsx` — `RunSeparator` компонент и кнопка-фильтр

## Test plan

- [ ] Запустить процесс дважды подряд — в консоли должны появиться два разделителя
- [ ] Нажать "Current run" — отображаются только логи последнего запуска
- [ ] Нажать "All runs" — снова отображаются все логи
- [ ] Существующие фильтры по уровню и поиск работают совместно с фильтром по запуску

Closes #296