### PR TITLE
perf(studio): skip autosave serialization on unchanged diagram (#297)

### DIFF
--- a/packages/studio/src/hooks/useAutoSave.ts
+++ b/packages/studio/src/hooks/useAutoSave.ts
@@ -151,6 +151,8 @@ export function useAutoSave(options: AutoSaveOptions = {}): {
   const pendingSaveRef = useRef<boolean>(false);
 
   const performSave = useCallback(async () => {
+    if (!isDirtyRef.current) return;
+
     const metadata = metadataRef.current;
     const nodes = nodesRef.current;
     const edges = edgesRef.current;

--- a/packages/studio/src/hooks/useAutoSave.ts
+++ b/packages/studio/src/hooks/useAutoSave.ts
@@ -150,8 +150,8 @@ export function useAutoSave(options: AutoSaveOptions = {}): {
   const rafRef = useRef<number | null>(null);
   const pendingSaveRef = useRef<boolean>(false);
 
-  const performSave = useCallback(async () => {
-    if (!isDirtyRef.current) return;
+  const performSave = useCallback(async (force = false) => {
+    if (!force && !isDirtyRef.current) return;
 
     const metadata = metadataRef.current;
     const nodes = nodesRef.current;
@@ -232,7 +232,7 @@ export function useAutoSave(options: AutoSaveOptions = {}): {
       rafRef.current = null;
     }
     pendingSaveRef.current = false;
-    await performSave();
+    await performSave(true);
   }, [performSave]);
 
   const clearBackup = useCallback(() => {


### PR DESCRIPTION
Closes #297

## Что сделано
- В `performSave` добавлена ранняя проверка `isDirtyRef.current` до вызова `serializeDiagram()` и `JSON.stringify`
- Если диаграмма не изменена (`isDirty === false`), сериализация полностью пропускается, что избавляет от лишних CPU-затрат на каждый тик автосохранения