### PR TITLE
feat(studio): добавить кнопку тоггла миникарты в тулбар дизайнера (#295)

### DIFF
--- a/packages/studio/public/locales/en/common.json
+++ b/packages/studio/public/locales/en/common.json
@@ -634,6 +634,7 @@
     "blockLegend": "Block Legend",
     "blockTypes": "Block Types",
     "moreOptions": "More Options",
+    "toggleMiniMap": "Toggle MiniMap",
     "entryPoint": "Entry point",
     "exitPoint": "Exit point",
     "decision": "Decision",

--- a/packages/studio/public/locales/ru/common.json
+++ b/packages/studio/public/locales/ru/common.json
@@ -626,6 +626,7 @@
     "blockLegend": "Легенда блоков",
     "blockTypes": "Типы блоков",
     "moreOptions": "Дополнительные опции",
+    "toggleMiniMap": "Показать/скрыть миникарту",
     "entryPoint": "Точка входа",
     "exitPoint": "Точка выхода",
     "decision": "Решение",

--- a/packages/studio/src/components/Designer/CanvasToolbar.tsx
+++ b/packages/studio/src/components/Designer/CanvasToolbar.tsx
@@ -11,6 +11,7 @@ import {
   FiRotateCcw,
   FiRotateCw,
   FiInfo,
+  FiMap,
 } from 'react-icons/fi';
 import { FaMinus, FaLongArrowAltRight } from 'react-icons/fa';
 import { useReactFlow } from '@reactflow/core';
@@ -29,6 +30,8 @@ interface CanvasToolbarProps {
   canRedo: boolean;
   onUndo: () => void;
   onRedo: () => void;
+  showMiniMap: boolean;
+  onToggleMiniMap: () => void;
 }
 
 const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
@@ -40,6 +43,8 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
   canRedo,
   onUndo,
   onRedo,
+  showMiniMap,
+  onToggleMiniMap,
 }) => {
   const { t } = useTranslation('common');
   const { getNodes, setNodes } = useReactFlow();
@@ -349,8 +354,22 @@ const CanvasToolbar: React.FC<CanvasToolbarProps> = ({
           }`}
           title={snapToGrid ? t('canvasToolbar.disableGrid') : t('canvasToolbar.enableGrid')}
           aria-label={snapToGrid ? t('canvasToolbar.disableGrid') : t('canvasToolbar.enableGrid')}
+          aria-pressed={snapToGrid}
         >
           <FiGrid className="w-4 h-4" />
+        </button>
+        <button
+          onClick={onToggleMiniMap}
+          className={`p-1.5 rounded transition-colors ${
+            showMiniMap
+              ? 'bg-indigo-100 text-indigo-600 hover:bg-indigo-200'
+              : 'hover:bg-slate-100 text-slate-600 hover:text-slate-900'
+          }`}
+          title={t('canvasToolbar.toggleMiniMap')}
+          aria-label={t('canvasToolbar.toggleMiniMap')}
+          aria-pressed={showMiniMap}
+        >
+          <FiMap className="w-4 h-4" />
         </button>
 
         <div className="relative" ref={edgeMenuRef}>

--- a/packages/studio/src/components/Designer/ProcessCanvas.tsx
+++ b/packages/studio/src/components/Designer/ProcessCanvas.tsx
@@ -30,6 +30,7 @@ import { useHistoryStore } from '../../stores/historyStore';
 import { useSelectionStore } from '../../stores/selectionStore';
 import { useExecutionStore } from '../../stores/executionStore';
 import { useDiagramStore } from '../../stores/diagramStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useThrottledCallback } from '../../hooks/useThrottledCallback';
 import CanvasToolbar, { type EdgeTypeOption } from './CanvasToolbar';
@@ -97,6 +98,9 @@ const ProcessCanvasInner: React.FC = () => {
   const redoHistory = useHistoryStore((state) => state.redo);
   const undoStack = useHistoryStore((state) => state.undoStack);
   const redoStack = useHistoryStore((state) => state.redoStack);
+
+  const showMiniMap = useSettingsStore((state) => state.designer.showMinimap);
+  const setDesignerSettings = useSettingsStore((state) => state.setDesignerSettings);
 
   const currentExecutingNodeId = useExecutionStore((state) => state.currentExecutingNodeId);
   const { breakpoints, addBreakpoint, removeBreakpoint } = useExecutionStore(
@@ -551,6 +555,8 @@ const ProcessCanvasInner: React.FC = () => {
             setEdges(snapshot.edges.map(ed => ({ ...ed, type: edgeType })));
           }
         }}
+        showMiniMap={showMiniMap}
+        onToggleMiniMap={() => setDesignerSettings({ showMinimap: !showMiniMap })}
       />
       <ReactFlow
         nodes={nodes}
@@ -612,11 +618,13 @@ const ProcessCanvasInner: React.FC = () => {
           </defs>
         </svg>
         <Controls />
-        <MiniMap
-          nodeColor={(node: Node<ProcessNodeData>) =>
-            node.id === currentExecutingNodeId ? '#6366f1' : '#94a3b8'
-          }
-        />
+        {showMiniMap && (
+          <MiniMap
+            nodeColor={(node: Node<ProcessNodeData>) =>
+              node.id === currentExecutingNodeId ? '#6366f1' : '#94a3b8'
+            }
+          />
+        )}
         <Background variant={BackgroundVariant.Dots} gap={20} size={1} />
       </ReactFlow>
 


### PR DESCRIPTION
## Summary

- Добавить кнопку `FiMap` с `aria-pressed` в `CanvasToolbar` (новые props `showMiniMap`/`onToggleMiniMap`)
- Читать `designer.showMinimap` из `useSettingsStore` в `ProcessCanvas` — значение персистируется через `zustand/persist`
- Условно рендерить `<MiniMap>` только при `showMiniMap === true`
- Добавить переводы `canvasToolbar.toggleMiniMap` в `en` и `ru`

## Test plan

- [ ] Открыть Designer, убедиться что миникарта отображается по умолчанию
- [ ] Нажать кнопку карты в тулбаре — миникарта скрывается, кнопка переходит в активное состояние (indigo)
- [ ] Нажать повторно — миникарта появляется снова
- [ ] Перезагрузить приложение — состояние (видима/скрыта) сохраняется
- [ ] Проверить `aria-pressed` атрибут кнопки меняется вместе с состоянием