### PR TITLE
stability: implement context manager for Credentials library (#367)

### DIFF
--- a/packages/libraries/src/rpaforge_libraries/Credentials/library.py
+++ b/packages/libraries/src/rpaforge_libraries/Credentials/library.py
@@ -60,6 +60,18 @@ class Credentials:
         self._env_vars_set: list[str] = []
         self._ensure_vault()
 
+    def __enter__(self) -> Credentials:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._cleanup_env_vars()
+
+    def _cleanup_env_vars(self) -> None:
+        for var in self._env_vars_set:
+            if var in os.environ:
+                del os.environ[var]
+        self._env_vars_set = []
+
     def _derive_key(
         self, password: str, salt: bytes | None = None
     ) -> tuple[bytes, bytes]:

--- a/packages/libraries/tests/test_credentials.py
+++ b/packages/libraries/tests/test_credentials.py
@@ -130,3 +130,29 @@ class TestCredentialsKeywords:
 
             for keyword in keywords:
                 assert hasattr(lib, keyword), f"Missing keyword: {keyword}"
+
+
+class TestCredentialsContextManager:
+    def test_context_manager_enter_returns_self(self):
+        from rpaforge_libraries.Credentials import Credentials
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Credentials(vault_path=Path(tmpdir) / "vault.json") as lib:
+                assert isinstance(lib, Credentials)
+
+    def test_context_manager_cleans_env_vars(self):
+        from rpaforge_libraries.Credentials import Credentials
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lib = Credentials(vault_path=Path(tmpdir) / "vault.json")
+            assert isinstance(lib._env_vars_set, list)
+            assert len(lib._env_vars_set) == 0
+
+    def test_context_manager_with_statement(self):
+        from rpaforge_libraries.Credentials import Credentials
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Credentials(vault_path=Path(tmpdir) / "vault.json") as lib:
+                lib.store_credential("test", "user", "pass")
+                cred = lib.get_credential("test")
+                assert cred["username"] == "user"


### PR DESCRIPTION
## Summary
Implement context manager for Credentials library (closes #367)

## Changes
- Add `__enter__` and `__exit__` methods to Credentials class
- Add `_cleanup_env_vars()` method for resource cleanup
- Add tests for context manager functionality

## Usage
```python
with Credentials() as cred:
    cred.store_credential("db", "admin", "password")
    # Environment variables automatically cleaned up on exit
```

## Files Changed
- `packages/libraries/src/rpaforge_libraries/Credentials/library.py`
- `packages/libraries/tests/test_credentials.py`