### PR TITLE
fix: batch fixes — security, stability, a11y, and bug fixes (#390, #391, #392, #394, #395, #396, #398, #399, #400)

### DIFF
--- a/packages/libraries/src/rpaforge_libraries/DataFrames/library.py
+++ b/packages/libraries/src/rpaforge_libraries/DataFrames/library.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 from rpaforge.core.activity import activity, library, output, param, tags
@@ -55,6 +56,8 @@ class DataFrames:
         has_header: bool = True,
     ) -> str:
         """Read a CSV file into a named DataFrame."""
+        if not Path(path).exists():
+            raise FileNotFoundError(f"CSV file not found: {path}")
         pl = self._pl
         df = pl.read_csv(path, separator=separator, has_header=has_header)
         self._frames[frame_name] = df
@@ -73,6 +76,8 @@ class DataFrames:
         sheet: str | None = None,
     ) -> str:
         """Read an Excel file into a named DataFrame."""
+        if not Path(path).exists():
+            raise FileNotFoundError(f"Excel file not found: {path}")
         pl = self._pl
         kwargs: dict[str, Any] = {}
         if sheet:
@@ -93,6 +98,8 @@ class DataFrames:
         frame_name: str = "df",
     ) -> str:
         """Read a JSON file into a named DataFrame."""
+        if not Path(path).exists():
+            raise FileNotFoundError(f"JSON file not found: {path}")
         pl = self._pl
         df = pl.read_json(path)
         self._frames[frame_name] = df

--- a/packages/libraries/src/rpaforge_libraries/DateTime/library.py
+++ b/packages/libraries/src/rpaforge_libraries/DateTime/library.py
@@ -248,7 +248,7 @@ class DateTime:
             return 1
         return 0
 
-    @activity(name="Is Between", category="DateTime")
+    @activity(name="Get Period Bounds", category="DateTime")
     @tags("datetime", "bounds")
     @output("Datetime at the specified bound")
     @param(

--- a/packages/libraries/src/rpaforge_libraries/Variables/library.py
+++ b/packages/libraries/src/rpaforge_libraries/Variables/library.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("rpaforge.variables")
 
+_MISSING = object()
+
 
 @library(name="Variables", category="Data", icon="📦")
 class Variables:
@@ -46,7 +48,7 @@ class Variables:
     def get_variable(
         self,
         name: str,
-        default: Any | None = None,
+        default: Any = _MISSING,
     ) -> Any:
         """Get a variable value.
 
@@ -56,7 +58,7 @@ class Variables:
         :raises KeyError: If variable doesn't exist and no default provided.
         """
         if name not in self._variables:
-            if default is not None:
+            if default is not _MISSING:
                 return default
             raise KeyError(f"Variable '{name}' not found")
         return self._variables[name]

--- a/packages/studio/electron/ipc-validator.ts
+++ b/packages/studio/electron/ipc-validator.ts
@@ -80,6 +80,14 @@ export function getProjectRoot(): string | null {
   return projectRoot;
 }
 
+export function validateProjectFilePath(value: unknown, paramName: string): void {
+  const root = getProjectRoot();
+  if (!root) {
+    throw new Error('IPC Security: project root not set — FS operation blocked');
+  }
+  validateFilePath(value, paramName, root);
+}
+
 export function validateMethodName(value: unknown): void {
   if (typeof value !== 'string') {
     throw new Error('Invalid IPC payload: method name must be a string');

--- a/packages/studio/electron/main.ts
+++ b/packages/studio/electron/main.ts
@@ -10,7 +10,7 @@ import type { LogEntry, OpenDialogOptions, SaveDialogOptions, FileInfo } from '.
 import type { BridgeState, BridgeStatus, FsEvent } from '../src/types/events';
 import { createLogger } from '../src/utils/logger';
 import { config } from '../src/config/app.config';
-import { validateMethodName, validateSafeString, validateFilePath, validateIPCPayload, setProjectRoot, getProjectRoot } from './ipc-validator';
+import { validateMethodName, validateSafeString, validateFilePath, validateIPCPayload, setProjectRoot, getProjectRoot, validateProjectFilePath } from './ipc-validator';
 
 // ESM polyfill for __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -154,7 +154,7 @@ function createWindow() {
       preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false,
+      sandbox: true,
     },
     title: 'RPAForge Studio',
     autoHideMenuBar: true,
@@ -233,7 +233,7 @@ function createSpyOverlay(): BrowserWindow {
       preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false,
+      sandbox: true,
     },
   });
 
@@ -580,12 +580,12 @@ function setupIPCHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_PATH_EXISTS, async (_, filePath: string) => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     return fs.existsSync(filePath);
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_READ_DIR, async (event, dirPath: string): Promise<FileInfo[]> => {
-    validateFilePath(dirPath, 'dirPath', getProjectRoot());
+    validateProjectFilePath(dirPath, 'dirPath');
     validateIPCPayload(event, 'fs:readDir', { dirPath });
     const entries = await fsp.readdir(dirPath, { withFileTypes: true });
     return entries.map((entry) => ({
@@ -598,13 +598,13 @@ function setupIPCHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_READ_FILE, async (event, filePath: string): Promise<string> => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     validateIPCPayload(event, 'fs:readFile', { filePath });
     return fsp.readFile(filePath, 'utf-8');
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_WRITE_FILE, async (event, filePath: string, content: string) => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     validateSafeString(content, 'content');
     validateIPCPayload(event, 'fs:writeFile', { filePath, content });
     validateSafeString(content, 'content');
@@ -612,45 +612,45 @@ function setupIPCHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_CREATE_DIR, async (event, dirPath: string) => {
-    validateFilePath(dirPath, 'dirPath', getProjectRoot());
+    validateProjectFilePath(dirPath, 'dirPath');
     validateIPCPayload(event, 'fs:createDir', { dirPath });
     await fsp.mkdir(dirPath, { recursive: true });
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_DELETE, async (event, targetPath: string, recursive = false) => {
-    validateFilePath(targetPath, 'targetPath', getProjectRoot());
+    validateProjectFilePath(targetPath, 'targetPath');
     validateIPCPayload(event, 'fs:delete', { targetPath, recursive });
     await fsp.rm(targetPath, { recursive, force: true });
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_RENAME, async (event, oldPath: string, newPath: string) => {
-    validateFilePath(oldPath, 'oldPath', getProjectRoot());
-    validateFilePath(newPath, 'newPath', getProjectRoot());
+    validateProjectFilePath(oldPath, 'oldPath');
+    validateProjectFilePath(newPath, 'newPath');
     validateIPCPayload(event, 'fs:rename', { oldPath, newPath });
     await fsp.rename(oldPath, newPath);
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_COPY, async (event, source: string, destination: string) => {
-    validateFilePath(source, 'source', getProjectRoot());
-    validateFilePath(destination, 'destination', getProjectRoot());
+    validateProjectFilePath(source, 'source');
+    validateProjectFilePath(destination, 'destination');
     validateIPCPayload(event, 'fs:copy', { source, destination });
     await fsp.cp(source, destination, { recursive: true });
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_OPEN_WITH_SYSTEM, async (event, filePath: string) => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     validateIPCPayload(event, 'fs:openWithSystem', { filePath });
     await shell.openPath(filePath);
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_SHOW_IN_FOLDER, async (event, filePath: string) => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     validateIPCPayload(event, 'fs:showInFolder', { filePath });
     shell.showItemInFolder(filePath);
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_GET_FILE_INFO, async (event, filePath: string): Promise<FileInfo> => {
-    validateFilePath(filePath, 'filePath', getProjectRoot());
+    validateProjectFilePath(filePath, 'filePath');
     validateIPCPayload(event, 'fs:getFileInfo', { filePath });
     const stats = await fsp.stat(filePath);
     const name = path.basename(filePath);
@@ -666,7 +666,7 @@ function setupIPCHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_WATCH_DIR, async (event, dirPath: string) => {
-    validateFilePath(dirPath, 'dirPath', getProjectRoot());
+    validateProjectFilePath(dirPath, 'dirPath');
     validateIPCPayload(event, 'fs:watchDir', { dirPath });
     if (fsWatchers.has(dirPath)) {
       return;
@@ -725,7 +725,7 @@ function setupIPCHandlers() {
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_UNWATCH_DIR, async (event, dirPath: string) => {
-    validateFilePath(dirPath, 'dirPath', getProjectRoot());
+    validateProjectFilePath(dirPath, 'dirPath');
     validateIPCPayload(event, 'fs:unwatchDir', { dirPath });
     const watcher = fsWatchers.get(dirPath);
     if (watcher) {

--- a/packages/studio/electron/preload.ts
+++ b/packages/studio/electron/preload.ts
@@ -1,10 +1,4 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-// ESM polyfill for __dirname in preload
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
 import type { StudioAPI, LogEntry } from '../src/types/ipc-contracts';
 import type { BridgeEvent, FileSystemEvent } from '../src/types/events';

--- a/packages/studio/public/locales/de/common.json
+++ b/packages/studio/public/locales/de/common.json
@@ -31,7 +31,8 @@
     "settings": "Einstellungen",
     "cancel": "Abbrechen",
     "ok": "OK",
-    "apply": "Anwenden"
+    "apply": "Anwenden",
+    "retry": "Wiederholen"
   },
   "toolbar": {
     "title": "RPAForge Studio",
@@ -261,7 +262,10 @@
       "parallel": "Parallel ausführen",
       "retryScope": "Bei Fehler wiederholen",
       "assign": "Variable erstellen oder aktualisieren"
-    }
+    },
+    "loadingActivities": "Aktivitäten werden geladen...",
+    "loadError": "Aktivitäten konnten nicht geladen werden",
+    "loadErrorHint": "Läuft die Python-Bridge?"
   },
   "console": {
     "searchPlaceholder": "Logs suchen...",
@@ -709,7 +713,10 @@
     "inputArgs": "Eingabeargumente",
     "outputArgs": "Ausgabeargumente",
     "editCode": "Code bearbeiten",
-    "editParam": "{{name}} bearbeiten"
+    "editParam": "{{name}} bearbeiten",
+    "confirmDelete": "Löschen?",
+    "deleteConfirm": "Löschen bestätigen",
+    "deleteCancel": "Löschen abbrechen"
   },
   "propertyEditors": {
     "parallel": {
@@ -984,5 +991,9 @@
     "exportCSV": "Als CSV exportieren",
     "searchPlaceholder": "Zeilen filtern...",
     "noData": "Keine Daten zum Anzeigen"
+  },
+  "activityDoc": {
+    "parameters": "Parameter",
+    "output": "Ausgabe"
   }
 }

--- a/packages/studio/public/locales/en/common.json
+++ b/packages/studio/public/locales/en/common.json
@@ -31,7 +31,8 @@
     "settings": "Settings",
     "cancel": "Cancel",
     "ok": "OK",
-    "apply": "Apply"
+    "apply": "Apply",
+    "retry": "Retry"
   },
   "toolbar": {
     "title": "RPAForge Studio",
@@ -265,7 +266,10 @@
       "parallel": "Execute in parallel",
       "retryScope": "Retry on failure",
       "assign": "Create or update variable"
-    }
+    },
+    "loadingActivities": "Loading activities...",
+    "loadError": "Could not load activities",
+    "loadErrorHint": "Is the Python bridge running?"
   },
   "console": {
     "searchPlaceholder": "Search logs...",
@@ -721,7 +725,10 @@
     "activityInfoLibrary": "Library",
     "activityInfoNoDescription": "No description available.",
     "activityInfoRequired": "required",
-    "activityInfoMoreParams": "+{{count}} more"
+    "activityInfoMoreParams": "+{{count}} more",
+    "confirmDelete": "Delete?",
+    "deleteConfirm": "Confirm deletion",
+    "deleteCancel": "Cancel deletion"
   },
   "propertyEditors": {
     "parallel": {
@@ -1009,5 +1016,9 @@
     "exportCSV": "Export as CSV",
     "searchPlaceholder": "Filter rows...",
     "noData": "No data to display"
+  },
+  "activityDoc": {
+    "parameters": "Parameters",
+    "output": "Output"
   }
 }

--- a/packages/studio/public/locales/ru/common.json
+++ b/packages/studio/public/locales/ru/common.json
@@ -31,7 +31,8 @@
     "settings": "Настройки",
     "cancel": "Отмена",
     "ok": "ОК",
-    "apply": "Применить"
+    "apply": "Применить",
+    "retry": "Повторить"
   },
   "settings": {
     "title": "Настройки",
@@ -264,7 +265,10 @@
       "parallel": "Параллельное выполнение",
       "retryScope": "Повтор при ошибке",
       "assign": "Создать или обновить переменную"
-    }
+    },
+    "loadingActivities": "Загрузка активностей...",
+    "loadError": "Не удалось загрузить активности",
+    "loadErrorHint": "Запущен ли Python bridge?"
   },
   "console": {
     "searchPlaceholder": "Поиск в логах...",
@@ -708,7 +712,10 @@
     "activityInfoLibrary": "Библиотека",
     "activityInfoNoDescription": "Описание недоступно.",
     "activityInfoRequired": "обязательный",
-    "activityInfoMoreParams": "+{{count}} ещё"
+    "activityInfoMoreParams": "+{{count}} ещё",
+    "confirmDelete": "Удалить?",
+    "deleteConfirm": "Подтвердить удаление",
+    "deleteCancel": "Отменить удаление"
   },
   "propertyEditors": {
     "subDiagram": {
@@ -1023,5 +1030,9 @@
     "exportCSV": "Экспорт в CSV",
     "searchPlaceholder": "Фильтр строк...",
     "noData": "Нет данных для отображения"
+  },
+  "activityDoc": {
+    "parameters": "Параметры",
+    "output": "Результат"
   }
 }

--- a/packages/studio/src/components/Designer/ActivityDocTooltip.tsx
+++ b/packages/studio/src/components/Designer/ActivityDocTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useId } from 'react';
 import ReactDOM from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import type { Activity } from '../../types/engine';
@@ -29,7 +29,7 @@ const PARAM_TYPE_COLORS: Record<string, string> = {
   dataframe: 'bg-pink-100 text-pink-700',
 };
 
-const TooltipContent: React.FC<{ activity: Activity; pos: TooltipPosition }> = ({ activity, pos }) => {
+const TooltipContent: React.FC<{ activity: Activity; pos: TooltipPosition; tooltipId: string }> = ({ activity, pos, tooltipId }) => {
   const libraryName = getActivityDisplayLibrary(activity);
   const { t } = useTranslation(getLibraryNamespace(libraryName));
   const { t: tCommon } = useTranslation('common');
@@ -44,6 +44,7 @@ const TooltipContent: React.FC<{ activity: Activity; pos: TooltipPosition }> = (
 
   return ReactDOM.createPortal(
     <div
+      id={tooltipId}
       className="fixed z-[9999] w-72 rounded-lg border border-slate-200 bg-white shadow-xl text-sm pointer-events-none"
       style={{ top: pos.top, left: pos.left }}
       role="tooltip"
@@ -62,7 +63,7 @@ const TooltipContent: React.FC<{ activity: Activity; pos: TooltipPosition }> = (
       {visibleParams.length > 0 && (
         <div className="px-3 py-2">
           <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1.5">
-            Parameters
+            {tCommon('activityDoc.parameters')}
           </div>
           <ul className="space-y-1">
             {visibleParams.slice(0, 6).map((param) => {
@@ -96,7 +97,7 @@ const TooltipContent: React.FC<{ activity: Activity; pos: TooltipPosition }> = (
       {activity.has_output && activity.output_description && (
         <div className="px-3 py-2 border-t border-slate-100">
           <div className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-0.5">
-            Output
+            {tCommon('activityDoc.output')}
           </div>
           <div className="text-slate-700 leading-snug">{activity.output_description}</div>
         </div>
@@ -110,6 +111,7 @@ export const ActivityDocTooltip: React.FC<ActivityDocTooltipProps> = ({ activity
   const [pos, setPos] = useState<TooltipPosition | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const tooltipId = useId();
 
   const show = useCallback(() => {
     timerRef.current = setTimeout(() => {
@@ -118,7 +120,9 @@ export const ActivityDocTooltip: React.FC<ActivityDocTooltipProps> = ({ activity
       const tooltipWidth = 288; // w-72
       const spaceRight = window.innerWidth - rect.right;
       const left = spaceRight >= tooltipWidth + 8 ? rect.right + 8 : rect.left - tooltipWidth - 8;
-      const top = Math.min(rect.top, window.innerHeight - 320);
+      const estimatedHeight = 320;
+      const spaceBelow = window.innerHeight - rect.top;
+      const top = spaceBelow >= estimatedHeight ? rect.top : Math.max(rect.top - estimatedHeight + rect.height, 4);
       setPos({ top, left });
     }, 400);
   }, []);
@@ -133,10 +137,18 @@ export const ActivityDocTooltip: React.FC<ActivityDocTooltipProps> = ({ activity
 
   useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current); }, []);
 
-  return (
-    <div ref={containerRef} onMouseEnter={show} onMouseLeave={hide} className="contents">
+   return (
+    <div 
+      ref={containerRef} 
+      onMouseEnter={show} 
+      onMouseLeave={hide} 
+      onFocus={show} 
+      onBlur={hide} 
+      className="contents"
+      {...(pos ? { 'aria-describedby': tooltipId } : {})}
+    >
       {children}
-      {pos && <TooltipContent activity={activity} pos={pos} />}
+      {pos && <TooltipContent activity={activity} pos={pos} tooltipId={tooltipId} />}
     </div>
   );
 };

--- a/packages/studio/src/components/Designer/ActivityPalette.tsx
+++ b/packages/studio/src/components/Designer/ActivityPalette.tsx
@@ -20,6 +20,7 @@ import {
   FiChevronRight,
   FiInfo,
   FiMenu,
+  FiAlertCircle,
 } from 'react-icons/fi';
 import EmptyState from '../Common/EmptyState';
 import {
@@ -565,7 +566,7 @@ const ActivityCategorySection: React.FC<ActivityCategorySectionProps> = ({
 
 const ActivityPalette: React.FC = () => {
   const { t } = useTranslation('common');
-  const { categories, isLoading } = useDesigner();
+  const { categories, isLoading, error, refreshActivities } = useDesigner();
   const searchQuery = useDesignerStore((s) => s.activitySearchQuery);
   const setSearchQuery = useDesignerStore((s) => s.setActivitySearchQuery);
   const [categoryOrder, setCategoryOrder] = useState<string[]>([]);
@@ -724,7 +725,24 @@ const ActivityPalette: React.FC = () => {
           </div>
         )}
         {isLoading && (
-          <div className="px-3 pb-2 text-xs text-slate-500">{t('palette.loading')}</div>
+          <div className="flex flex-col items-center justify-center py-8 text-center px-4">
+            <div className="w-8 h-8 border-2 border-indigo-400 border-t-transparent rounded-full animate-spin mb-2" role="status" aria-label={t('palette.loadingActivities')} />
+            <p className="text-sm text-slate-500">{t('palette.loadingActivities')}</p>
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div className="flex flex-col items-center justify-center py-8 text-center px-4">
+            <FiAlertCircle className="w-8 h-8 text-red-400 mb-2" />
+            <p className="text-sm text-slate-600 font-medium mb-1">{t('palette.loadError')}</p>
+            <p className="text-xs text-slate-400 mb-3">{t('palette.loadErrorHint')}</p>
+            <button
+              onClick={() => refreshActivities()}
+              className="px-3 py-1.5 text-sm bg-indigo-50 text-indigo-600 rounded-md hover:bg-indigo-100 transition-colors font-medium"
+            >
+              {t('actions.retry')}
+            </button>
+          </div>
         )}
 
         {searchQuery && !hasSearchResults && (

--- a/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
+++ b/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
@@ -89,7 +89,7 @@ const PropertyPanel: React.FC = () => {
   const selectedSubDiagram = blockData && isSubDiagramCallBlock(blockData) ? getDiagram(blockData.diagramId) : undefined;
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden" role="complementary" aria-labelledby="property-panel-title">
       <PanelHeader title={title} subtitle={subtitle} nodeId={selectedNodeId || undefined} onDelete={handleDeleteNode} onInfo={activity ? () => setShowActivityDoc(true) : undefined} />
       {showActivityDoc && activity && (
         <ActivityDocModal activity={activity} onClose={() => setShowActivityDoc(false)} />
@@ -159,7 +159,7 @@ const PropertyPanel: React.FC = () => {
 const NoParametersState: React.FC<{ blockType: string }> = ({ blockType }) => {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col items-center justify-center py-8 text-center px-4">
+    <div className="flex flex-col items-center justify-center py-8 text-center px-4" role="status" aria-live="polite">
       <FiSliders className="w-8 h-8 text-slate-300 dark:text-slate-600 mb-2" aria-hidden="true" />
       <p className="text-sm text-slate-500 dark:text-slate-400">
         {blockType === 'start' || blockType === 'end'
@@ -226,6 +226,7 @@ const DiagramInputsOutputs: React.FC<{ diagram: DiagramMetadata | null }> = ({ d
 const PanelHeader: React.FC<{ title: string; subtitle?: string; nodeId?: string; onDelete: () => void; onInfo?: () => void }> = ({ title, subtitle, nodeId, onDelete, onInfo }) => {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
+  const [confirming, setConfirming] = useState(false);
 
   const handleCopyId = async () => {
     if (nodeId) {
@@ -261,13 +262,33 @@ const PanelHeader: React.FC<{ title: string; subtitle?: string; nodeId?: string;
               {copied ? <FiCheck className="h-4 w-4 text-green-500" /> : <FiCopy className="h-4 w-4" />}
             </button>
           )}
-          <button
-            className="rounded p-1.5 text-slate-400 hover:bg-slate-200 hover:text-red-500 dark:hover:bg-slate-700"
-            onClick={onDelete}
-            aria-label={t('propertyPanel.deleteNode')}
-          >
-            <FiTrash2 className="h-4 w-4" aria-hidden="true" />
-          </button>
+          {confirming ? (
+            <div className="flex items-center gap-1">
+              <span className="text-xs text-red-500 font-medium">{t('propertyPanel.confirmDelete')}</span>
+              <button
+                className="rounded p-1.5 text-red-500 hover:bg-red-50 dark:hover:bg-red-900/30"
+                onClick={() => { setConfirming(false); onDelete(); }}
+                aria-label={t('propertyPanel.deleteConfirm')}
+              >
+                <FiCheck className="h-4 w-4" />
+              </button>
+              <button
+                className="rounded p-1.5 text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700"
+                onClick={() => setConfirming(false)}
+                aria-label={t('propertyPanel.deleteCancel')}
+              >
+                <FiX className="h-4 w-4" />
+              </button>
+            </div>
+          ) : (
+            <button
+              className="rounded p-1.5 text-slate-400 hover:bg-slate-200 hover:text-red-500 dark:hover:bg-slate-700"
+              onClick={() => setConfirming(true)}
+              aria-label={t('propertyPanel.deleteNode')}
+            >
+              <FiTrash2 className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
         </div>
       </div>
       {subtitle && <div className="mt-1 text-xs text-slate-500">{subtitle}</div>}

--- a/packages/studio/src/hooks/useDesigner.ts
+++ b/packages/studio/src/hooks/useDesigner.ts
@@ -27,6 +27,7 @@ export interface UseDesignerResult {
   undoAvailable: boolean;
   redoAvailable: boolean;
   isLoading: boolean;
+  error: string | null;
 
   selectNode: (id: string | null) => void;
   deselectNode: () => void;
@@ -82,15 +83,18 @@ export const useDesigner = (): UseDesignerResult => {
   const { getActivities } = useEngine();
   const [categories, setCategories] = useState<ActivityCategory[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const refreshActivities = useCallback(async () => {
     setIsLoading(true);
+    setError(null);
 
     try {
       const result = normalizeActivitiesResult(await getActivities());
       setCategories(groupActivitiesByCategory(result.activities));
     } catch (err) {
       logger.error('Failed to fetch activities', err);
+      setError(err instanceof Error ? err.message : 'Failed to load activities');
       setCategories([]);
     } finally {
       setIsLoading(false);
@@ -227,6 +231,7 @@ export const useDesigner = (): UseDesignerResult => {
     undoAvailable,
     redoAvailable,
     isLoading,
+    error,
     selectNode,
     deselectNode,
     undo,

--- a/packages/studio/src/stores/diagramStore.ts
+++ b/packages/studio/src/stores/diagramStore.ts
@@ -11,33 +11,33 @@ import { useVariableStore } from './variableStore';
  * Delays writes to prevent I/O bottlenecks during rapid state changes.
  */
 function debouncedStorage(delayMs: number) {
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  let pendingWrite: { name: string; value: string } | null = null;
+  const pendingWrites = new Map<string, string>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
 
   return createJSONStorage(() => ({
     getItem: (name: string) => {
-      if (pendingWrite && pendingWrite.name === name) {
-        return pendingWrite.value;
+      if (pendingWrites.has(name)) {
+        return pendingWrites.get(name)!;
       }
       return localStorage.getItem(name);
     },
     setItem: (name: string, value: string) => {
-      if (timer !== null) {
-        clearTimeout(timer);
+      pendingWrites.set(name, value);
+      if (timers.has(name)) {
+        clearTimeout(timers.get(name)!);
       }
-      pendingWrite = { name, value };
-      timer = setTimeout(() => {
-        localStorage.setItem(name, value);
-        pendingWrite = null;
-        timer = null;
-      }, delayMs);
+      timers.set(name, setTimeout(() => {
+        localStorage.setItem(name, pendingWrites.get(name)!);
+        pendingWrites.delete(name);
+        timers.delete(name);
+      }, delayMs));
     },
     removeItem: (name: string) => {
-      if (timer !== null) {
-        clearTimeout(timer);
-        timer = null;
+      if (timers.has(name)) {
+        clearTimeout(timers.get(name)!);
+        timers.delete(name);
       }
-      pendingWrite = null;
+      pendingWrites.delete(name);
       localStorage.removeItem(name);
     },
   }));


### PR DESCRIPTION
## Summary

Batch fix PR addressing 9 issues across security, stability, UX/a11y, and Python libraries.

## Changes

### 🔒 Security
- **#390** — Enable Electron sandbox for `mainWindow` and `spyOverlayWindow`. Cleaned up preload.ts by removing Node.js built-in imports (`path`, `fileURLToPath`) that don't work in sandbox mode.
- **#391** — Block FS operations until `projectRoot` is set. Added `validateProjectFilePath()` wrapper that throws if `projectRoot` is null. All 14 FS IPC handlers now require project root.

### 🐛 Bug Fixes
- **#398** — Fix duplicate `@activity(name="Is Between")` in DateTime library. Renamed `get_period_bounds` to `"Get Period Bounds"`.
- **#399** — Variables `get_variable` now accepts `None` as an explicit default value via sentinel pattern.
- **#400** — DataFrames `read_csv`/`read_excel`/`read_json` raise clear `FileNotFoundError` instead of opaque Polars errors.

### 🛡️ Stability
- **#392** — Fix race condition in `debouncedStorage`: replaced single `pendingWrite` slot with `Map`-based approach to prevent data loss under rapid concurrent writes.

### ♿ Accessibility & UX
- **#394** — PropertyPanel: added `role="complementary"` landmark, delete button confirmation dialog, `role="status"` on empty state.
- **#395** — ActivityDocTooltip: added keyboard (`onFocus`/`onBlur`) support, i18n for "Parameters"/"Output" strings, `aria-describedby` linkage, bottom-overflow guard.
- **#396** — ActivityPalette: added loading spinner (replaces raw text), error state with retry button and descriptive message.

### 🌐 i18n
- Added translation keys for all new UI strings across en/ru/de locales.

## Testing
- ✅ All 379 Python library tests pass
- ✅ TypeScript compilation clean (`tsc --noEmit`)
- ✅ Ruff format clean on all modified Python files
- ✅ LSP diagnostics clean on all TypeScript files

## Commits
1. `fix(libraries): add FileNotFoundError checks, Variables sentinel, fix DateTime duplicate name`
2. `security(electron): enable sandbox mode and add project root validation for FS ops`
3. `fix(stability): replace single pendingWrite with Map in debouncedStorage to prevent data loss`
4. `feat(ux): add loading spinner and error state with retry to ActivityPalette`
5. `a11y(designer): add keyboard accessibility, i18n strings, and overflow guard to ActivityDocTooltip`
6. `a11y(designer): add ARIA landmarks, delete confirmation, and status role to PropertyPanel`
7. `i18n: add translation keys for ActivityDocTooltip, PropertyPanel, and ActivityPalette`