### PR TITLE
fix: thread safety, Credentials security, and WebUI resource leaks

### DIFF
--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -268,6 +268,7 @@ class ProcessExecutor:
         self._listeners: list[Callable] = []
         self._context: ExecutionContext | None = None
         self._lock = threading.Lock()
+        self._circuit_lock = threading.Lock()
         self._subprocess_executor: SubprocessExecutor | None = (
             SubprocessExecutor()
             if _USE_SUBPROCESS and SubprocessExecutor is not None
@@ -280,11 +281,13 @@ class ProcessExecutor:
         logger.debug(f"Registered library: {name}")
 
     def add_listener(self, callback: Callable) -> None:
-        self._listeners.append(callback)
+        with self._lock:
+            self._listeners.append(callback)
 
     def remove_listener(self, callback: Callable) -> None:
-        if callback in self._listeners:
-            self._listeners.remove(callback)
+        with self._lock:
+            if callback in self._listeners:
+                self._listeners.remove(callback)
 
     def cancel(self) -> None:
         pass
@@ -658,7 +661,9 @@ class ProcessExecutor:
         return self._timeout_handler.execute_with_timeout(_call, args, timeout_ms)
 
     def _notify(self, event_type: str, *args: Any) -> None:
-        for listener in self._listeners:
+        with self._lock:
+            listeners = list(self._listeners)
+        for listener in listeners:
             try:
                 listener(event_type, *args)
             except Exception as e:
@@ -689,59 +694,61 @@ class ProcessExecutor:
         return f"{activity.library}.{activity.activity}"
 
     def _check_circuit_breaker(self, activity: ActivityCall) -> tuple[bool, str | None]:
-        circuit_key = self._get_circuit_key(activity)
-        if circuit_key not in self._circuit_breakers:
+        with self._circuit_lock:
+            circuit_key = self._get_circuit_key(activity)
+            if circuit_key not in self._circuit_breakers:
+                return True, None
+
+            state = self._circuit_breakers[circuit_key]
+            now = time.time()
+
+            if state.state == CircuitState.OPEN:
+                if now - state.state_changed_at >= 60.0:
+                    state.state = CircuitState.HALF_OPEN
+                    state.state_changed_at = now
+                    logger.info(
+                        f"Circuit breaker HALF_OPEN for {circuit_key}: testing recovery"
+                    )
+                    return True, "HALF_OPEN (testing recovery)"
+                return False, "OPEN (circuit tripped)"
+
+            if state.state == CircuitState.HALF_OPEN:
+                return True, "HALF_OPEN (recovery test)"
+
             return True, None
 
-        state = self._circuit_breakers[circuit_key]
-        now = time.time()
-
-        if state.state == CircuitState.OPEN:
-            if now - state.state_changed_at >= 60.0:
-                state.state = CircuitState.HALF_OPEN
-                state.state_changed_at = now
-                logger.info(
-                    f"Circuit breaker HALF_OPEN for {circuit_key}: testing recovery"
-                )
-                return True, "HALF_OPEN (testing recovery)"
-            return False, "OPEN (circuit tripped)"
-
-        if state.state == CircuitState.HALF_OPEN:
-            return True, "HALF_OPEN (recovery test)"
-
-        return True, None
-
     def _update_circuit_breaker(self, activity: ActivityCall, success: bool) -> None:
-        circuit_key = self._get_circuit_key(activity)
-        if circuit_key not in self._circuit_breakers:
-            self._circuit_breakers[circuit_key] = CircuitBreakerState()
+        with self._circuit_lock:
+            circuit_key = self._get_circuit_key(activity)
+            if circuit_key not in self._circuit_breakers:
+                self._circuit_breakers[circuit_key] = CircuitBreakerState()
 
-        state = self._circuit_breakers[circuit_key]
-        now = time.time()
+            state = self._circuit_breakers[circuit_key]
+            now = time.time()
 
-        if success:
-            if state.state == CircuitState.HALF_OPEN:
-                state.state = CircuitState.CLOSED
-                state.failures = 0
-                state.state_changed_at = now
-                logger.info(
-                    f"Circuit breaker CLOSED for {circuit_key}: service recovered"
-                )
-            elif state.state == CircuitState.CLOSED:
-                state.failures = 0
-        else:
-            state.failures += 1
-            state.last_failure_time = now
+            if success:
+                if state.state == CircuitState.HALF_OPEN:
+                    state.state = CircuitState.CLOSED
+                    state.failures = 0
+                    state.state_changed_at = now
+                    logger.info(
+                        f"Circuit breaker CLOSED for {circuit_key}: service recovered"
+                    )
+                elif state.state == CircuitState.CLOSED:
+                    state.failures = 0
+            else:
+                state.failures += 1
+                state.last_failure_time = now
 
-            if state.state == CircuitState.HALF_OPEN:
-                state.state = CircuitState.OPEN
-                state.state_changed_at = now
-                logger.warning(
-                    f"Circuit breaker OPEN for {circuit_key}: recovery test failed"
-                )
-            elif state.state == CircuitState.CLOSED and state.failures >= 3:
-                state.state = CircuitState.OPEN
-                state.state_changed_at = now
-                logger.warning(
-                    f"Circuit breaker OPEN for {circuit_key}: {state.failures} consecutive failures"
-                )
+                if state.state == CircuitState.HALF_OPEN:
+                    state.state = CircuitState.OPEN
+                    state.state_changed_at = now
+                    logger.warning(
+                        f"Circuit breaker OPEN for {circuit_key}: recovery test failed"
+                    )
+                elif state.state == CircuitState.CLOSED and state.failures >= 3:
+                    state.state = CircuitState.OPEN
+                    state.state_changed_at = now
+                    logger.warning(
+                        f"Circuit breaker OPEN for {circuit_key}: {state.failures} consecutive failures"
+                    )

--- a/packages/libraries/src/rpaforge_libraries/Credentials/library.py
+++ b/packages/libraries/src/rpaforge_libraries/Credentials/library.py
@@ -32,7 +32,6 @@ def _atomic_write(path: Path, data: bytes, mode: int = 0o600) -> None:
 
 
 VAULT_KEY_FILE = Path.home() / ".rpaforge" / ".vault.key"
-VAULT_KEY_FILE = Path.home() / ".rpaforge" / ".vault.key"
 
 try:
     from cryptography.fernet import Fernet
@@ -158,6 +157,10 @@ class Credentials:
                 decrypted = fernet.decrypt(data)
                 self._credentials = json.loads(decrypted)
             else:
+                logger.warning(
+                    "Vault data is not encrypted — credentials are stored in plaintext. "
+                    "Re-save the vault to enable encryption."
+                )
                 self._credentials = json.loads(data)
 
         except (json.JSONDecodeError, FileNotFoundError):

--- a/packages/libraries/src/rpaforge_libraries/WebUI/library.py
+++ b/packages/libraries/src/rpaforge_libraries/WebUI/library.py
@@ -31,6 +31,7 @@ class WebUI:
         self._browsers: dict[str, Any] = {}
         self._contexts: dict[str, Any] = {}
         self._pages: dict[str, Any] = {}
+        self._page_browser: dict[str, str] = {}
         self._current_browser_id: str | None = None
         self._current_page_id: str | None = None
         self._timeout: int = 30000
@@ -127,6 +128,7 @@ class WebUI:
 
         self._contexts[instance_id] = context
         self._pages[instance_id] = page
+        self._page_browser[instance_id] = instance_id
         self._current_browser_id = instance_id
         self._current_page_id = instance_id
 
@@ -163,6 +165,7 @@ class WebUI:
 
         self._contexts[instance_id] = context
         self._pages[instance_id] = page
+        self._page_browser[instance_id] = self._current_browser_id
         self._current_page_id = instance_id
 
         if url:
@@ -802,6 +805,7 @@ class WebUI:
             if target_id in self._contexts:
                 self._contexts[target_id].close()
                 del self._contexts[target_id]
+            self._page_browser.pop(target_id, None)
             logger.info(f"Closed page: {target_id}")
 
         if self._current_page_id == target_id:
@@ -827,6 +831,7 @@ class WebUI:
             self._pages.clear()
             self._contexts.clear()
             self._browsers.clear()
+            self._page_browser.clear()
             self._current_browser_id = None
             self._current_page_id = None
 
@@ -843,14 +848,23 @@ class WebUI:
 
         if target_id in self._browsers:
             for page_id in list(self._pages.keys()):
-                if page_id == target_id or page_id.startswith(f"{target_id}_"):
+                if self._page_browser.get(page_id) == target_id:
                     with contextlib.suppress(Exception):
                         self._pages[page_id].close()
+                    with contextlib.suppress(Exception):
+                        if page_id in self._contexts:
+                            self._contexts[page_id].close()
                     self._pages.pop(page_id, None)
                     self._contexts.pop(page_id, None)
+                    self._page_browser.pop(page_id, None)
 
             self._browsers[target_id].close()
             del self._browsers[target_id]
+
+            if not self._browsers and self._playwright:
+                self._playwright.stop()
+                self._playwright = None
+
             logger.info(f"Closed browser: {target_id}")
 
         if self._current_browser_id == target_id:


### PR DESCRIPTION
## Summary

Fixes three issues across core and libraries:

- **#407 [CRITICAL/SECURITY]** `Credentials/library.py`: removed duplicate `VAULT_KEY_FILE` constant (line 35 shadowed line 34); added `logger.warning` when vault data is loaded as plaintext so users know their credentials are not encrypted
- **#408 [CRITICAL/STABILITY]** `executor.py`: added thread safety for concurrent execution scenarios:
  - `add_listener`/`remove_listener` now hold `self._lock` to prevent concurrent modification
  - `_notify` takes a snapshot of `_listeners` under lock before iterating — prevents `RuntimeError: list changed size during iteration`
  - `_check_circuit_breaker` and `_update_circuit_breaker` now hold a dedicated `_circuit_lock` — prevents race conditions when multiple parallel branches update the same circuit breaker state
- **#409 [CRITICAL/STABILITY]** `WebUI/library.py`: fixed context and playwright leaks:
  - Added `_page_browser: dict[str, str]` to track which browser owns each page
  - `close_browser(all=False)` now closes ALL pages and contexts belonging to the target browser (previously only closed the initial page)
  - `close_browser` stops the playwright instance when the last browser is closed
  - `close_page` and `new_page` maintain the ownership mapping

## Test plan

- [ ] `packages/libraries/tests` — 466 passed locally (2 pre-existing unrelated failures)
- [ ] ruff lint + format: all 3 files clean
- [ ] CI green (lint → test matrix → build)