### PR TITLE
fix: output preload as .cjs to fix ESM SyntaxError in Electron sandbox (#442)

### DIFF
--- a/packages/studio/electron/main.ts
+++ b/packages/studio/electron/main.ts
@@ -140,9 +140,9 @@ function createWindow() {
   let preloadPath: string;
   
   if (isDev) {
-    preloadPath = path.join(process.cwd(), 'dist-electron', 'electron', 'preload.js');
+    preloadPath = path.join(process.cwd(), 'dist-electron', 'electron', 'preload.cjs');
   } else {
-    preloadPath = path.join(__dirname, 'preload.js');
+    preloadPath = path.join(__dirname, 'preload.cjs');
   }
 
   mainWindow = new BrowserWindow({
@@ -214,8 +214,8 @@ function createSpyOverlay(): BrowserWindow {
   logger.info(`Creating spy overlay: ${width}x${height}`);
 
   const preloadPath = isDev
-    ? path.join(process.cwd(), 'dist-electron', 'electron', 'preload.js')
-    : path.join(__dirname, 'preload.js');
+    ? path.join(process.cwd(), 'dist-electron', 'electron', 'preload.cjs')
+    : path.join(__dirname, 'preload.cjs');
 
   spyOverlayWindow = new BrowserWindow({
     width,

--- a/packages/studio/vite.config.ts
+++ b/packages/studio/vite.config.ts
@@ -95,6 +95,7 @@ export default defineConfig({
               output: {
                 format: 'cjs',
                 inlineDynamicImports: true,
+                entryFileNames: 'preload.cjs',
               },
             },
           },


### PR DESCRIPTION
## Summary

Closes #442

- `packages/studio/electron/main.ts` — оба места (`createWindow` и `createSpyOverlay`) теперь загружают `preload.cjs` вместо `preload.js`
- `packages/studio/vite.config.ts` — добавлен `entryFileNames: 'preload.cjs'` в rollup output preload-записи

## Root cause

`package.json` содержит `"type": "module"`, из-за чего Node.js/Electron трактует любой `.js` как ESM — независимо от настройки `format: 'cjs'` в rollup. Файл `.cjs` Node.js всегда трактует как CommonJS, что требуется для sandboxed preload Electron.

## Test plan

- [ ] `vite build` — `dist-electron/electron/preload.cjs` создаётся с `"use strict"` и `require("electron")` (не `import`)
- [ ] Приложение запускается в dev-режиме без `SyntaxError: Cannot use import statement outside a module`
- [ ] `contextBridge.exposeInMainWorld('rpaforge', ...)` работает и API доступен в renderer