### PR TITLE
fix(ui): improve loading and empty states in components (#418)

### DIFF
--- a/packages/studio/src/components/Debugger/CallStackPanel.tsx
+++ b/packages/studio/src/components/Debugger/CallStackPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { FiChevronRight, FiFile } from 'react-icons/fi';
+import { FiChevronRight, FiFile, FiCode } from 'react-icons/fi';
+import EmptyState from '../Common/EmptyState';
 import { useDebuggerStore } from '../../stores/debuggerStore';
 import type { CallFrame } from '../../types/engine';
 
@@ -12,11 +13,16 @@ const CallStackPanel: React.FC = () => {
 
   if (callStack.length === 0) {
     return (
-      <div className="p-4">
-        <h2 className="font-semibold mb-4">{t('callStack.title')}</h2>
-        <div className="text-center text-sm text-slate-500 dark:text-slate-400 py-4">
-          {t('callStack.noCallStack')}
-          <div className="text-xs mt-1">{t('callStack.startDebugging')}</div>
+      <div className="h-full flex flex-col">
+        <div className="p-3 border-b border-slate-200 dark:border-slate-700">
+          <h2 className="font-semibold">{t('callStack.title')}</h2>
+        </div>
+        <div className="flex-1">
+          <EmptyState
+            icon={<FiCode className="w-8 h-8" />}
+            title={t('callStack.noCallStack')}
+            description={t('callStack.startDebugging')}
+          />
         </div>
       </div>
     );

--- a/packages/studio/src/components/Designer/DiagramExplorer.tsx
+++ b/packages/studio/src/components/Designer/DiagramExplorer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
-import ConfirmDialog from '../Common/ConfirmDialog';
+import { useTranslation } from 'react-i18next';
 import {
   FiFile,
   FiFileText,
@@ -16,6 +16,9 @@ import {
   FiSettings,
   FiExternalLink,
 } from 'react-icons/fi';
+import ConfirmDialog from '../Common/ConfirmDialog';
+import EmptyState from '../Common/EmptyState';
+import { Spinner } from '../Common/Loading';
 import { useDiagramStore, type DiagramMetadata, type DiagramType } from '../../stores/diagramStore';
 import { useProjectFsStore, type ProjectFile } from '../../stores/projectFsStore';
 import DiagramSettingsDialog from './DiagramSettingsDialog';
@@ -42,6 +45,7 @@ const DiagramExplorer: React.FC<DiagramExplorerProps> = ({
   onSelectDiagram,
   activeDiagramId,
 }) => {
+  const { t } = useTranslation('common');
   const {
     project,
     addDiagram,
@@ -756,14 +760,15 @@ const DiagramExplorer: React.FC<DiagramExplorerProps> = ({
         onDrop={handleDropOnRoot}
       >
         {isLoading ? (
-          <div className="px-4 py-8 text-center text-sm text-slate-500" role="status" aria-live="polite">
-            <p>Loading...</p>
+          <div className="flex items-center justify-center py-12" role="status" aria-live="polite">
+            <Spinner size="md" className="text-slate-400" />
           </div>
         ) : tree.length === 0 ? (
-          <div className="px-4 py-8 text-center text-sm text-slate-500">
-            <p>No files yet</p>
-            <p className="text-xs mt-1">Right-click to create</p>
-          </div>
+          <EmptyState
+            icon={<FiFilePlus className="w-8 h-8" />}
+            title={t('diagramExplorer.noFiles')}
+            description={t('diagramExplorer.rightClickCreate')}
+          />
         ) : (
           tree.map((node) => renderNode(node))
         )}

--- a/packages/studio/src/components/Recorder/ActionList.tsx
+++ b/packages/studio/src/components/Recorder/ActionList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FiMousePointer, FiType, FiList, FiNavigation, FiKey, FiTrash2, FiDownload } from 'react-icons/fi';
+import { FiMousePointer, FiType, FiList, FiNavigation, FiKey, FiTrash2, FiDownload, FiActivity } from 'react-icons/fi';
+import EmptyState from '../Common/EmptyState';
 import type { RecordedAction, CandidateSelector } from './SelectorInference';
 
 interface ActionListProps {
@@ -83,11 +84,11 @@ const ActionList: React.FC<ActionListProps> = ({ actions, onUpdate, onDelete, on
   const { t } = useTranslation('common');
   if (actions.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center p-4 text-xs text-slate-400 dark:text-slate-500 text-center">
-        {t('actionList.noActions')}
-        <br />
-        {t('actionList.startRecording')}
-      </div>
+      <EmptyState
+        icon={<FiActivity className="w-8 h-8" />}
+        title={t('actionList.noActions')}
+        description={t('actionList.startRecording')}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

Partially resolves #418 - Missing loading, empty, and error states across components.

### Changes
- **DiagramExplorer.tsx**: 
  - Replaced plain "Loading..." text with `Spinner` component
  - Replaced "No files yet" plain div with `EmptyState` component
  
- **ActionList.tsx** (Recorder):
  - Replaced plain text empty state with `EmptyState` component with `FiActivity` icon

- **CallStackPanel.tsx** (Debugger):
  - Replaced plain text empty state with `EmptyState` component with `FiCode` icon

### Before/After

**Before:** Plain text with no visual hierarchy
```
Loading...
No files yet
Right-click to create
```

**After:** Consistent EmptyState component with icon and i18n support
```
┌─────────────────────────┐
│         📁+             │
│    No files yet         │
│  Right-click to create  │
└─────────────────────────┘
```

### Test Plan
- [x] TypeScript compiles without errors
- [x] All components use existing EmptyState pattern
- [x] i18n translations already exist (diagramExplorer.noFiles, actionList.noActions, callStack.noCallStack)

## Labels
- ux
- bug