### PR TITLE
ci(release): PyPI Trusted Publishing + fail loudly + decouple from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,13 @@ on:
 
 jobs:
   build:
-    name: Build and Publish
+    name: Build and Release
     runs-on: ubuntu-latest
     permissions:
       # contents: write -- needed to upload release assets to the GitHub Release.
+      # PyPI publishing (and its id-token: write) lives in the separate
+      # publish-pypi job, so a publish failure cannot block the release/installer.
       contents: write
-      # id-token: write -- required for OIDC-based Trusted Publishing to PyPI
-      # (passwordless authentication; no stored API token needed when fully configured).
-      id-token: write
 
     steps:
       # fetch-depth: 0 fetches the full git history including all tags so that
@@ -66,19 +65,14 @@ jobs:
       - name: Check packages
         run: twine check dist/*
 
-      # Upload to PyPI only on manual dispatch so accidental release events
-      # do not trigger an unwanted publish.
-      # --skip-existing allows re-running the workflow without failing if the
-      # version was already uploaded (idempotent publish).
-      # TWINE_USERNAME/__token__ is the standard PyPI API token auth convention.
-      - name: Publish to PyPI
-        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
-        run: |
-          python -m pip install twine
-          python -m twine upload dist/* --skip-existing || echo "Upload skipped or failed"
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      # Hand the validated distributions to the separate publish-pypi job. Keeping
+      # the PyPI upload out of this job means a PyPI failure fails loudly on its
+      # own without blocking the GitHub Release or the Windows installer.
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       # Create a GitHub Release and attach the built distribution files.
       # generate_release_notes: true auto-populates the release body from merged
@@ -95,6 +89,36 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    # Only real releases (tag push or manual dispatch) publish; a "release:
+    # published" event skips publishing, matching the previous behaviour.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    permissions:
+      # id-token: write -- mints the short-lived OIDC token for Trusted Publishing.
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      # Trusted Publishing (OIDC) — no stored API token. Requires a GitHub
+      # trusted publisher configured on PyPI for BOTH rpaforge-core and
+      # rpaforge-libraries:
+      #   PyPI -> project -> Settings -> Publishing -> add a GitHub publisher
+      #     Owner: chelslava   Repository: rpaforge   Workflow: release.yml
+      # No `|| echo` mask: a real upload failure fails this job loudly instead of
+      # silently shipping a release without the packages. skip-existing keeps
+      # re-runs idempotent when a version was already uploaded.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   build-electron:
     name: Build and Attach Windows Installer


### PR DESCRIPTION
## Проблема

Шаг публикации в PyPI был замаскирован `|| echo "Upload skipped or failed"`, поэтому **403 Forbidden** (невалидный/отсутствующий `PYPI_API_TOKEN`) проходил молча. В результате PyPI не получил версии 0.3.1–0.3.5 (latest там до сих пор 0.3.0), хотя релизы были «зелёными».

## Изменения

- Переход на **Trusted Publishing (OIDC)** через `pypa/gh-action-pypi-publish` — без хранимого токена.
- Убрана маска `|| echo` — реальный сбой загрузки теперь **роняет джобу**, а не прячется.
- Публикация вынесена в отдельную джобу **`publish-pypi`** (`needs: build`). GitHub Release и Windows-инсталлятор больше **не зависят** от успеха PyPI — сбой публикации виден, но изолирован и не блокирует релиз.

`build` теперь отдаёт дистрибутивы артефактом `dist`, который `publish-pypi` скачивает.

## Требуется однократная настройка на стороне PyPI (за тобой)

Для **обоих** проектов (`rpaforge-core` и `rpaforge-libraries`):
PyPI → проект → Settings → Publishing → добавить GitHub trusted publisher:
- Owner: `chelslava`, Repository: `rpaforge`, Workflow: `release.yml`, Environment: пусто

После настройки следующий тег `v*.*.*` опубликует пакеты автоматически. Для добивки текущей 0.3.5: перезапустить джобу `publish-pypi` последнего релизного прогона (артефакт `dist` с 0.3.5 уже собран; `skip-existing` сделает повтор идемпотентным).

## Проверка
YAML валиден, джобы: build, publish-pypi, build-electron.