### PR TITLE
fix(studio): bridge crashes from read-only install dir (v0.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-06-03
+
+### Fixed
+- Installed app: the bundled engine crashed on startup with a permission error (`.rpaforge_checkpoints` could not be created) when launched from a read-only location such as Program Files. The engine now runs in a writable per-user working directory, so the bridge starts and activities load.
+
 ## [0.3.5] - 2026-06-03
 
 ### Added

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rpaforge-core"
-version = "0.3.5"
+version = "0.3.6"
 description = "Native Python execution engine"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/libraries/pyproject.toml
+++ b/packages/libraries/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rpaforge-libraries"
-version = "0.3.5"
+version = "0.3.6"
 description = "RPA automation libraries for RPAForge"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/packages/studio/electron/main.ts
+++ b/packages/studio/electron/main.ts
@@ -390,7 +390,17 @@ function resolveBridgeLaunchSpec(): BridgeLaunchSpec | null {
     PATH: `${tesseractDir}${path.delimiter}${process.env.PATH ?? ''}`,
   };
 
-  return { command, args: [], env };
+  // The engine creates CWD-relative paths (e.g. `.rpaforge_checkpoints`). An app
+  // launched from Program Files has a read-only CWD, so the engine would crash on
+  // startup with a permission error. Run it in a writable per-user directory.
+  const workingDir = path.join(app.getPath('userData'), 'engine');
+  try {
+    fs.mkdirSync(workingDir, { recursive: true });
+  } catch (error) {
+    logger.error('Failed to create engine working directory:', workingDir, error);
+  }
+
+  return { command, args: [], env, cwd: workingDir };
 }
 
 async function initializePythonBridge() {

--- a/packages/studio/electron/python-bridge.ts
+++ b/packages/studio/electron/python-bridge.ts
@@ -52,6 +52,14 @@ export interface BridgeLaunchSpec {
    * PLAYWRIGHT_BROWSERS_PATH, Tesseract via PATH/TESSDATA_PREFIX).
    */
   env?: Record<string, string>;
+  /**
+   * Working directory for the engine process. The engine creates CWD-relative
+   * paths (e.g. `.rpaforge_checkpoints`), so in a packaged build this must be a
+   * writable location — the default CWD of an app launched from Program Files is
+   * read-only and the engine would crash on startup. Unset in development, where
+   * the inherited CWD (the repo) is already writable.
+   */
+  cwd?: string;
 }
 
 type BridgeStateDetails = {
@@ -272,12 +280,15 @@ export class PythonBridge {
     const generation = this.activeProcessGeneration + 1;
     this.activeProcessGeneration = generation;
 
-    const { command, args, env: extraEnv } = this.resolveLaunchSpec();
+    const { command, args, env: extraEnv, cwd } = this.resolveLaunchSpec();
     const child = this.spawnChildProcess(command, args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       // windowsHide prevents the bundled console executable from flashing a
       // terminal window on Windows; stdio pipes work regardless of the window.
       windowsHide: true,
+      // A writable cwd in packaged builds (see BridgeLaunchSpec.cwd); undefined
+      // in dev so the child inherits the repo working directory.
+      cwd,
       env: {
         ...process.env,
         PYTHONUNBUFFERED: '1',

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpaforge-studio",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "RPAForge Studio - Visual RPA IDE built on Electron and React",
   "type": "module",
   "main": "dist-electron/electron/main.js",


### PR DESCRIPTION
## Проблема

В установленном приложении (`C:\Program Files\RPAForge Studio`) Studio грузится, но **мост не стартует**. Движок упакован корректно — диагностика показала, что замороженный exe падает на старте:

```
OSError: Failed to create checkpoint directory '.rpaforge_checkpoints':
[WinError 5] Отказано в доступе
```

`StudioEngine` создаёт `.rpaforge_checkpoints` **относительно рабочей директории**. Приложение, запущенное из `Program Files`, наследует **read-only** CWD → отказ в доступе → мост падает. В dev не воспроизводилось (CWD = записываемый репозиторий).

Подтверждено на ПК пользователя: тот же exe из записываемой папки (`%TEMP%`) отвечает `pong`; из `Program Files` — `WinError 5`.

## Фикс

- В `BridgeLaunchSpec` добавлен `cwd`; spawn моста его использует.
- В проде `main.ts` запускает движок с `cwd = userData/engine` (записываемая per-user папка, создаётся при старте). В dev CWD остаётся унаследованным (репозиторий).

Bump → **0.3.6**.

## Проверка
tsc по electron — чисто; тесты бриджа — 5 passed. (Реальная проверка установленного движка: exe отвечает `pong` из записываемого CWD.)