### PR TITLE
fix(studio): allow project creation in new folders (0.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.8] - 2026-06-04
+
+### Fixed
+- Creating a project in a folder failed with `Failed to create project: ... rootPath is not accessible`. Two issues were addressed: (1) the renderer set the project root before the folder existed, and (2) the IPC path validator rejected not-yet-created paths because it `realpath`-ed the full target. The `fs:setProjectRoot` handler now creates the folder before validating, a dedicated `validateProjectRoot` validates the user-chosen root without confining it to the process cwd, and `validateFilePath` now resolves the nearest existing ancestor so new files and subdirectories validate correctly while still blocking symlink traversal and restricted system paths.
+
 ## [0.3.7] - 2026-06-04
 
 ### Fixed

--- a/packages/studio/electron/ipc-validator.ts
+++ b/packages/studio/electron/ipc-validator.ts
@@ -57,26 +57,90 @@ export function validateFilePath(value: unknown, paramName: string, allowedRoot:
     throw new Error(`Invalid IPC payload: ${paramName} contains invalid characters`);
   }
 
-  let resolved: string;
+  // The target may not exist yet (creating a new file/dir), so resolve it
+  // lexically and realpath only the nearest EXISTING ancestor — that defeats
+  // symlink traversal while still allowing not-yet-created leaves.
+  const absolute = path.resolve(value);
+
+  const cwd = fs.realpathSync(process.cwd());
+  let baseDir: string;
   try {
-    resolved = fs.realpathSync(value);
-  } catch (error) {
+    baseDir = allowedRoot ? fs.realpathSync(allowedRoot) : cwd;
+  } catch {
     throw new Error(`Invalid IPC payload: ${paramName} is not accessible`);
   }
 
-  const cwd = fs.realpathSync(process.cwd());
-  const baseDir = allowedRoot ? fs.realpathSync(allowedRoot) : cwd;
-
-  if (!resolved.startsWith(baseDir + path.sep) && resolved !== baseDir) {
-    if (!resolved.startsWith(cwd + path.sep) && resolved !== cwd) {
-      throw new Error(`Invalid IPC payload: ${paramName} is outside the allowed project directory`);
+  let probe = absolute;
+  let realExisting: string | null = null;
+  for (;;) {
+    try {
+      realExisting = fs.realpathSync(probe);
+      break;
+    } catch {
+      const parent = path.dirname(probe);
+      if (parent === probe) break;
+      probe = parent;
     }
+  }
+  if (realExisting === null) {
+    throw new Error(`Invalid IPC payload: ${paramName} is not accessible`);
+  }
+
+  const within = (p: string, base: string): boolean =>
+    p === base || p.startsWith(base + path.sep);
+
+  // Both the existing portion (after symlink resolution) and the full lexical
+  // target must stay inside the allowed root (or the cwd fallback).
+  const ok = (p: string): boolean => within(p, baseDir) || within(p, cwd);
+  if (!ok(realExisting) || !ok(absolute)) {
+    throw new Error(`Invalid IPC payload: ${paramName} is outside the allowed project directory`);
   }
 
   const blockedSegments = ['.ssh', '.aws', '.gnupg', '.rpaforge', '.config' + path.sep + 'gh'];
-  if (blockedSegments.some((seg) => resolved.includes(path.sep + seg + path.sep) || resolved.endsWith(path.sep + seg))) {
+  if (blockedSegments.some((seg) => absolute.includes(path.sep + seg + path.sep) || absolute.endsWith(path.sep + seg))) {
     throw new Error(`Invalid IPC payload: ${paramName} accesses a restricted path`);
   }
+}
+
+const RESTRICTED_SEGMENTS = ['.ssh', '.aws', '.gnupg', '.rpaforge', '.config' + path.sep + 'gh'];
+
+/**
+ * Validate a user-chosen project root. Unlike {@link validateFilePath}, this does
+ * NOT confine the path to `process.cwd()`: the project root is the trust anchor
+ * the user explicitly selects (via an OS folder dialog), and every later file
+ * operation is confined to it by {@link validateProjectFilePath}. It still
+ * rejects sensitive system locations and anything that is not a real directory.
+ * Returns the resolved absolute path.
+ */
+export function validateProjectRoot(value: unknown, paramName: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid IPC payload: ${paramName} must be a string`);
+  }
+
+  if (value.includes('\x00') || /[\x00-\x1F]/.test(value)) {
+    throw new Error(`Invalid IPC payload: ${paramName} contains invalid characters`);
+  }
+
+  let resolved: string;
+  try {
+    resolved = fs.realpathSync(value);
+  } catch {
+    throw new Error(`Invalid IPC payload: ${paramName} is not accessible`);
+  }
+
+  if (!fs.statSync(resolved).isDirectory()) {
+    throw new Error(`Invalid IPC payload: ${paramName} must be a directory`);
+  }
+
+  if (
+    RESTRICTED_SEGMENTS.some(
+      (seg) => resolved.includes(path.sep + seg + path.sep) || resolved.endsWith(path.sep + seg)
+    )
+  ) {
+    throw new Error(`Invalid IPC payload: ${paramName} accesses a restricted path`);
+  }
+
+  return resolved;
 }
 
 export function setProjectRoot(root: string | null): void {

--- a/packages/studio/electron/main.ts
+++ b/packages/studio/electron/main.ts
@@ -10,7 +10,7 @@ import type { LogEntry, OpenDialogOptions, SaveDialogOptions, FileInfo } from '.
 import type { BridgeState, BridgeStatus, FsEvent } from '../src/types/events';
 import { createLogger } from '../src/utils/logger';
 import { config } from '../src/config/app.config';
-import { validateMethodName, validateSafeString, validateFilePath, validateIPCPayload, setProjectRoot, getProjectRoot, validateProjectFilePath } from './ipc-validator';
+import { validateMethodName, validateSafeString, validateFilePath, validateIPCPayload, setProjectRoot, getProjectRoot, validateProjectFilePath, validateProjectRoot } from './ipc-validator';
 
 // ESM polyfill for __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -671,14 +671,20 @@ function setupIPCHandlers() {
 
   ipcMain.handle(IPC_CHANNELS.FS_SET_PROJECT_ROOT, async (_, rootPath: string) => {
     validateSafeString(rootPath, 'rootPath');
-    validateFilePath(rootPath, 'rootPath');
 
-    if (!fs.statSync(rootPath).isDirectory()) {
-      throw new Error('Project root must be a directory');
-    }
+    // Establish the project directory: for a brand-new project this is where its
+    // folder first comes into existence (the renderer sets the root before any
+    // file lives in it). Creating it here also breaks the chicken-and-egg with
+    // fs:createDir, which requires a project root to already be set.
+    await fsp.mkdir(rootPath, { recursive: true });
 
-    setProjectRoot(rootPath);
-    logger.info(`Project root set to: ${rootPath}`);
+    // Validate the chosen root without confining it to process.cwd(): the user
+    // explicitly picked this folder (e.g. under Documents), and all later file
+    // operations are confined to it by validateProjectFilePath.
+    const resolved = validateProjectRoot(rootPath, 'rootPath');
+
+    setProjectRoot(resolved);
+    logger.info(`Project root set to: ${resolved}`);
   });
 
   ipcMain.handle(IPC_CHANNELS.FS_PATH_EXISTS, async (_, filePath: string) => {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpaforge-studio",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "RPAForge Studio - Visual RPA IDE built on Electron and React",
   "type": "module",
   "main": "dist-electron/electron/main.js",


### PR DESCRIPTION
## Problem
Creating a project in a folder failed with `Failed to create project: ... rootPath is not accessible`.

Two root causes:
1. The renderer (`newProjectInFolder`) called `setProjectRoot(folder)` **before** the folder existed.
2. The IPC path validator (`validateFilePath`) `realpath`-ed the **full** target, which throws for not-yet-created paths (every new project/file/subdir).

## Fix
- `fs:setProjectRoot` handler now `mkdir`s the folder (recursive) before validating.
- New `validateProjectRoot` validates the user-chosen root **without** confining it to `process.cwd()` — the root is the trust anchor the user explicitly selects via the OS folder dialog. Still blocks restricted system paths (`.ssh`, `.aws`, `.gnupg`, `.rpaforge`, `.config/gh`) and non-directories.
- `validateFilePath` now resolves the **nearest existing ancestor** and checks both it and the lexical target stay within the allowed root — new files/subdirs validate while symlink traversal is still defeated.

## Verification
- Logic-level test (tsx) replicating the exact `newProjectInFolder` sequence: **PASS**
- **UI test against the built `win-unpacked` app** via Playwright `_electron.launch()`: the real `window.rpaforge.fs` `setProjectRoot → createDir → writeFile` sequence succeeds and files land on disk in `Documents`: **PASS**

Bumps studio to 0.3.8.