### PR TITLE
feat(studio): improve the Python code editor UX

### DIFF
--- a/packages/studio/public/locales/en/common.json
+++ b/packages/studio/public/locales/en/common.json
@@ -875,6 +875,25 @@
     "descriptionPlaceholder": "Variable description..."
   },
   "codeEditor": {
+    "editor": {
+      "title": "Edit Python Code",
+      "save": "Save",
+      "saveHint": "Save (Ctrl+S)",
+      "apply": "Apply",
+      "applyHint": "Apply without closing",
+      "cancel": "Cancel",
+      "maximize": "Maximize",
+      "restore": "Restore",
+      "formatHint": "Format (Ctrl+Shift+F)",
+      "formatOnSave": "Format on save",
+      "nextProblem": "Go to next problem",
+      "saved": "Saved",
+      "modified": "Modified",
+      "unsavedTitle": "Discard changes?",
+      "unsavedMessage": "You have unsaved changes. Are you sure you want to discard them?",
+      "discard": "Discard",
+      "keepEditing": "Keep editing"
+    },
     "variablesPanel": {
       "searchPlaceholder": "Search variables...",
       "addVariablesHint": "Add variables in the Variables panel"

--- a/packages/studio/public/locales/ru/common.json
+++ b/packages/studio/public/locales/ru/common.json
@@ -1,4 +1,25 @@
 {
+  "codeEditor": {
+    "editor": {
+      "title": "Редактирование Python-кода",
+      "save": "Сохранить",
+      "saveHint": "Сохранить (Ctrl+S)",
+      "apply": "Применить",
+      "applyHint": "Применить, не закрывая",
+      "cancel": "Отмена",
+      "maximize": "Развернуть",
+      "restore": "Свернуть",
+      "formatHint": "Форматировать (Ctrl+Shift+F)",
+      "formatOnSave": "Форматировать при сохранении",
+      "nextProblem": "Перейти к следующей проблеме",
+      "saved": "Сохранено",
+      "modified": "Изменено",
+      "unsavedTitle": "Отменить изменения?",
+      "unsavedMessage": "Есть несохранённые изменения. Точно отменить их?",
+      "discard": "Отменить",
+      "keepEditing": "Продолжить редактирование"
+    }
+  },
   "app": {
     "name": "RPAForge Студия",
     "about": "О RPAForge"

--- a/packages/studio/src/components/CodeEditor/CodeToolbar.tsx
+++ b/packages/studio/src/components/CodeEditor/CodeToolbar.tsx
@@ -57,7 +57,7 @@ const CodeToolbar: React.FC<CodeToolbarProps> = ({
         <button
           onClick={onFormat}
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 rounded transition-colors"
-          title={t('codeEditor.toolbar.formatCode')}
+          title={t('codeEditor.editor.formatHint')}
         >
           <FiCode className="w-4 h-4" />
           <span>{t('format')}</span>

--- a/packages/studio/src/components/CodeEditor/StatusBar.tsx
+++ b/packages/studio/src/components/CodeEditor/StatusBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { FiAlertCircle, FiAlertTriangle } from 'react-icons/fi';
 
 interface StatusBarProps {
@@ -9,6 +10,7 @@ interface StatusBarProps {
   isSaved?: boolean;
   errors?: number;
   warnings?: number;
+  onNextProblem?: () => void;
 }
 
 const StatusBar: React.FC<StatusBarProps> = ({
@@ -19,7 +21,25 @@ const StatusBar: React.FC<StatusBarProps> = ({
   isSaved = true,
   errors = 0,
   warnings = 0,
+  onNextProblem,
 }) => {
+  const { t } = useTranslation('common');
+  const ProblemCounts = (
+    <div className="flex items-center gap-3">
+      {errors > 0 && (
+        <span className="flex items-center gap-1 text-red-600 dark:text-red-400">
+          <FiAlertCircle className="w-3 h-3" />
+          {errors}
+        </span>
+      )}
+      {warnings > 0 && (
+        <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+          <FiAlertTriangle className="w-3 h-3" />
+          {warnings}
+        </span>
+      )}
+    </div>
+  );
   return (
     <div className="flex items-center justify-between px-4 py-1.5 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 text-xs text-slate-500 dark:text-slate-400">
       <div className="flex items-center gap-4">
@@ -33,20 +53,18 @@ const StatusBar: React.FC<StatusBarProps> = ({
         {(errors > 0 || warnings > 0) && (
           <>
             <span className="text-slate-300 dark:text-slate-600">|</span>
-            <div className="flex items-center gap-3">
-              {errors > 0 && (
-                <span className="flex items-center gap-1 text-red-600 dark:text-red-400">
-                  <FiAlertCircle className="w-3 h-3" />
-                  {errors}
-                </span>
-              )}
-              {warnings > 0 && (
-                <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
-                  <FiAlertTriangle className="w-3 h-3" />
-                  {warnings}
-                </span>
-              )}
-            </div>
+            {onNextProblem ? (
+              <button
+                type="button"
+                onClick={onNextProblem}
+                title={t('codeEditor.editor.nextProblem')}
+                className="flex items-center rounded hover:bg-slate-200 dark:hover:bg-slate-700 px-1 -mx-1 transition-colors"
+              >
+                {ProblemCounts}
+              </button>
+            ) : (
+              ProblemCounts
+            )}
           </>
         )}
       </div>
@@ -61,7 +79,7 @@ const StatusBar: React.FC<StatusBarProps> = ({
               isSaved ? 'bg-green-500' : 'bg-amber-500'
             }`}
           />
-          {isSaved ? 'Saved' : 'Modified'}
+          {isSaved ? t('codeEditor.editor.saved') : t('codeEditor.editor.modified')}
         </span>
       </div>
     </div>

--- a/packages/studio/src/components/CodeEditor/hooks/useRPACompletions.ts
+++ b/packages/studio/src/components/CodeEditor/hooks/useRPACompletions.ts
@@ -10,6 +10,60 @@ interface RPACompletionCache {
 
 const DEFAULT_CACHE_TTL = 5 * 60 * 1000;
 
+/**
+ * Heuristic: is the cursor inside a string literal or comment on this line?
+ * Single-line scan (does not track triple-quoted strings across lines), which is
+ * enough to stop activity/library completions from popping up while the user
+ * types prose such as a log message.
+ */
+function isInStringOrComment(textBeforeCursor: string): boolean {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < textBeforeCursor.length; i++) {
+    const ch = textBeforeCursor[i];
+    if (ch === '#' && !inSingle && !inDouble) {
+      return true;
+    }
+    if (ch === "'" && !inDouble && textBeforeCursor[i - 1] !== '\\') {
+      inSingle = !inSingle;
+    } else if (ch === '"' && !inSingle && textBeforeCursor[i - 1] !== '\\') {
+      inDouble = !inDouble;
+    }
+  }
+  return inSingle || inDouble;
+}
+
+/**
+ * Find the function call that encloses the cursor and which argument (0-based)
+ * the cursor is currently in, by scanning the line left of the cursor.
+ */
+function findEnclosingCall(
+  textBeforeCursor: string
+): { name: string; argIndex: number } | null {
+  let depth = 0;
+  let argIndex = 0;
+  let openIndex = -1;
+  for (let i = textBeforeCursor.length - 1; i >= 0; i--) {
+    const ch = textBeforeCursor[i];
+    if (ch === ')') {
+      depth++;
+    } else if (ch === '(') {
+      if (depth === 0) {
+        openIndex = i;
+        break;
+      }
+      depth--;
+    } else if (ch === ',' && depth === 0) {
+      argIndex++;
+    }
+  }
+  if (openIndex < 0) {
+    return null;
+  }
+  const match = textBeforeCursor.slice(0, openIndex).match(/([A-Za-z_]\w*)\s*$/);
+  return match ? { name: match[1], argIndex } : null;
+}
+
 export function useRPACompletions() {
   const [activities, setActivities] = useState<Activity[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -47,7 +101,7 @@ export function useRPACompletions() {
   }, []);
 
   useEffect(() => {
-    fetchActivities();
+    void fetchActivities();
   }, [fetchActivities]);
 
   const registerCompletions = useCallback(
@@ -61,6 +115,20 @@ export function useRPACompletions() {
             endLineNumber: position.lineNumber,
             endColumn: position.column,
           });
+
+          if (isInStringOrComment(textUntilPosition)) {
+            return { suggestions: [] };
+          }
+
+          // Replace the word under the cursor so Monaco filters the list by the
+          // typed prefix instead of showing every activity at once.
+          const word = model.getWordUntilPosition(position);
+          const wordRange = {
+            startLineNumber: position.lineNumber,
+            startColumn: word.startColumn,
+            endLineNumber: position.lineNumber,
+            endColumn: word.endColumn,
+          };
 
           const activitySuggestions: Monaco.languages.CompletionItem[] = activities.map(
             (activity) => ({
@@ -82,12 +150,7 @@ export function useRPACompletions() {
                 isTrusted: true,
               },
               detail: activity.library,
-              range: {
-                startLineNumber: position.lineNumber,
-                startColumn: position.column,
-                endLineNumber: position.lineNumber,
-                endColumn: position.column,
-              },
+              range: wordRange,
             })
           );
 
@@ -106,12 +169,7 @@ export function useRPACompletions() {
               value: `**${lib}** - RPAForge ${lib} library`,
               isTrusted: true,
             },
-            range: {
-              startLineNumber: position.lineNumber,
-              startColumn: position.column,
-              endLineNumber: position.lineNumber,
-              endColumn: position.column,
-            },
+            range: wordRange,
           }));
 
           const dotMatch = textUntilPosition.match(/(\w+)\.(\w*)$/);
@@ -203,9 +261,57 @@ export function useRPACompletions() {
         },
       });
 
+      const signatureDisposable = monaco.languages.registerSignatureHelpProvider(
+        'python',
+        {
+          signatureHelpTriggerCharacters: ['(', ','],
+          signatureHelpRetriggerCharacters: [','],
+          provideSignatureHelp: (model, position) => {
+            const textUntilPosition = model.getValueInRange({
+              startLineNumber: position.lineNumber,
+              startColumn: 1,
+              endLineNumber: position.lineNumber,
+              endColumn: position.column,
+            });
+
+            const call = findEnclosingCall(textUntilPosition);
+            if (!call) return null;
+
+            const activity = activities.find((a) => a.name === call.name);
+            if (!activity || activity.params.length === 0) return null;
+
+            const paramLabels = activity.params.map(
+              (param) => `${param.name}: ${param.type}`
+            );
+
+            return {
+              value: {
+                signatures: [
+                  {
+                    label: `${activity.name}(${paramLabels.join(', ')})`,
+                    documentation: activity.description,
+                    parameters: activity.params.map((param, index) => ({
+                      label: paramLabels[index],
+                      documentation: param.description || '',
+                    })),
+                  },
+                ],
+                activeSignature: 0,
+                activeParameter: Math.min(
+                  call.argIndex,
+                  activity.params.length - 1
+                ),
+              },
+              dispose: () => {},
+            };
+          },
+        }
+      );
+
       return () => {
         disposable.dispose();
         hoverDisposable.dispose();
+        signatureDisposable.dispose();
       };
     },
     [activities]

--- a/packages/studio/src/components/Designer/PythonCodeEditor.tsx
+++ b/packages/studio/src/components/Designer/PythonCodeEditor.tsx
@@ -135,6 +135,10 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
           column: e.position.column,
         });
       });
+
+      // Put the caret in the editor on open instead of the first focusable
+      // chrome control, so the user can type immediately.
+      editor.focus();
     },
     [editorTheme]
   );
@@ -423,6 +427,10 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
               insertSpaces: true,
               automaticLayout: true,
               formatOnPaste: true,
+              // Render hover/suggest/overlay widgets in a fixed layer attached to
+              // <body> so they are not clipped or mispositioned inside the fixed
+              // modal (and tooltips like "Close (Escape)" dismiss correctly).
+              fixedOverflowWidgets: true,
               // Suppress completion pop-ups inside strings and comments so typing
               // prose (e.g. a Cyrillic log message) is not interrupted by the
               // activity/library suggestion list.

--- a/packages/studio/src/components/Designer/PythonCodeEditor.tsx
+++ b/packages/studio/src/components/Designer/PythonCodeEditor.tsx
@@ -1,15 +1,19 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Editor, { type OnMount } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
+import { useTranslation } from 'react-i18next';
 import { FiX, FiCheck, FiMaximize2, FiMinimize2 } from 'react-icons/fi';
 
 import StatusBar from '../CodeEditor/StatusBar';
 import CodeToolbar from '../CodeEditor/CodeToolbar';
 import SnippetPanel from '../CodeEditor/SnippetPanel';
 import VariablesPanel from '../CodeEditor/VariablesPanel';
+import ConfirmDialog from '../Common/ConfirmDialog';
 import { useRPACompletions } from '../CodeEditor/hooks/useRPACompletions';
 import { useForcedColors, useResolvedTheme } from '../../hooks/useTheme';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useVariableStore } from '../../stores/variableStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import type { Snippet } from '../CodeEditor/data/snippets';
 import type { ValidationError } from '../../types/ipc-contracts';
 
@@ -26,10 +30,14 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
   code: initialCode,
   onClose,
   onSave,
-  title = 'Edit Python Code',
+  title,
 }) => {
+  const { t } = useTranslation('common');
+  const editorSettings = useSettingsStore((state) => state.editor);
+  const setEditorSettings = useSettingsStore((state) => state.setEditorSettings);
   const [code, setCode] = useState(initialCode);
   const [isMaximized, setIsMaximized] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
   const [isSnippetPanelOpen, setIsSnippetPanelOpen] = useState(false);
   const [isVariablesPanelOpen, setIsVariablesPanelOpen] = useState(false);
   const [cursorPosition, setCursorPosition] = useState({ line: 1, column: 1 });
@@ -46,6 +54,8 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
   const resolvedTheme = useResolvedTheme();
   const forcedColors = useForcedColors();
   const editorTheme = forcedColors ? (resolvedTheme === 'dark' ? 'hc-black' : 'hc-light') : (resolvedTheme === 'dark' ? 'vs-dark' : 'vs');
+
+  const modalRef = useFocusTrap<HTMLDivElement>(isOpen);
 
   const closeAllPanels = useCallback(() => {
     setIsSnippetPanelOpen(false);
@@ -73,11 +83,42 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
     }
   }, []);
 
-  const handleSave = useCallback(() => {
-    onSave(code);
+  const persist = useCallback(async (): Promise<string> => {
+    let toSave = code;
+    if (editorSettings.formatOnSave) {
+      try {
+        const result = await window.rpaforge?.editor.formatCode(code);
+        if (result?.formatted_code) {
+          toSave = result.formatted_code;
+          editorRef.current?.setValue(toSave);
+          setCode(toSave);
+        }
+      } catch (error) {
+        // Formatting is best-effort on save; never block saving on a format error.
+        console.error('Format on save failed:', error);
+      }
+    }
+    onSave(toSave);
     setIsDirty(false);
+    return toSave;
+  }, [code, editorSettings.formatOnSave, onSave]);
+
+  const handleSave = useCallback(() => {
+    void persist().then(() => onClose());
+  }, [persist, onClose]);
+
+  // Apply (save) without closing the editor.
+  const handleApply = useCallback(() => {
+    void persist();
+  }, [persist]);
+
+  const requestClose = useCallback(() => {
+    if (isDirty) {
+      setShowDiscardConfirm(true);
+      return;
+    }
     onClose();
-  }, [code, onSave, onClose]);
+  }, [isDirty, onClose]);
 
   const handleEditorDidMount: OnMount = useCallback(
     (editor, monaco) => {
@@ -120,7 +161,7 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
     );
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyG, () => {
       const action = editor.getAction('editor.action.gotoLine');
-      action?.run();
+      void action?.run();
     });
   }, [handleFormat]);
 
@@ -176,11 +217,11 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
   }, [code]);
 
   const handleFind = useCallback(() => {
-    editorRef.current?.getAction('actions.find')?.run();
+    void editorRef.current?.getAction('actions.find')?.run();
   }, []);
 
   const handleReplace = useCallback(() => {
-    editorRef.current?.getAction('editor.action.startFindReplaceAction')?.run();
+    void editorRef.current?.getAction('editor.action.startFindReplaceAction')?.run();
   }, []);
 
   const handleInsertSnippet = useCallback((snippet: Snippet) => {
@@ -232,16 +273,26 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
     setIsVariablesPanelOpen(false);
   }, []);
 
+  const handleNextProblem = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    editor.focus();
+    void editor.getAction('editor.action.marker.next')?.run();
+  }, []);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // While the discard-confirmation is open it owns the keyboard (Escape closes it).
+      if (showDiscardConfirm) return;
       if (e.key === 'Escape') {
-        onClose();
+        e.preventDefault();
+        requestClose();
       } else if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         handleSave();
       }
     },
-    [onClose, handleSave]
+    [showDiscardConfirm, requestClose, handleSave]
   );
 
   const handleCodeChange = useCallback((value: string | undefined) => {
@@ -265,17 +316,33 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
       onKeyDown={handleKeyDown}
     >
       <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title || t('codeEditor.editor.title')}
         className={`bg-white dark:bg-slate-800 rounded-lg shadow-xl flex flex-col ${
           isMaximized ? 'w-full h-full rounded-none' : 'w-full max-w-5xl h-[85vh]'
         }`}
       >
         <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700">
-          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">{title}</h2>
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+            {title || t('codeEditor.editor.title')}
+          </h2>
           <div className="flex items-center gap-2">
+            <label className="flex items-center gap-1.5 mr-1 text-xs text-slate-600 dark:text-slate-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                className="rounded border-slate-300 dark:border-slate-600"
+                checked={editorSettings.formatOnSave}
+                onChange={(e) => setEditorSettings({ formatOnSave: e.target.checked })}
+              />
+              {t('codeEditor.editor.formatOnSave')}
+            </label>
             <button
               className="p-1.5 hover:bg-slate-100 dark:hover:bg-slate-700 rounded text-slate-600 dark:text-slate-300"
               onClick={() => setIsMaximized(!isMaximized)}
-              title={isMaximized ? 'Restore' : 'Maximize'}
+              title={isMaximized ? t('codeEditor.editor.restore') : t('codeEditor.editor.maximize')}
+              aria-label={isMaximized ? t('codeEditor.editor.restore') : t('codeEditor.editor.maximize')}
             >
               {isMaximized ? (
                 <FiMinimize2 className="w-5 h-5" />
@@ -284,18 +351,27 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
               )}
             </button>
             <button
+              className="px-3 py-1.5 border border-slate-300 dark:border-slate-600 rounded text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-1 disabled:opacity-50"
+              onClick={handleApply}
+              disabled={!isDirty}
+              title={t('codeEditor.editor.applyHint')}
+            >
+              {t('codeEditor.editor.apply')}
+            </button>
+            <button
               className="px-3 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 flex items-center gap-1"
               onClick={handleSave}
+              title={t('codeEditor.editor.saveHint')}
             >
               <FiCheck className="w-4 h-4" />
-              Save
+              {t('codeEditor.editor.save')}
             </button>
             <button
               className="px-3 py-1.5 border border-slate-300 dark:border-slate-600 rounded text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-1"
-              onClick={onClose}
+              onClick={requestClose}
             >
               <FiX className="w-4 h-4" />
-              Cancel
+              {t('codeEditor.editor.cancel')}
             </button>
           </div>
         </div>
@@ -336,19 +412,21 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
             onChange={handleCodeChange}
             theme={editorTheme}
             options={{
-              minimap: { enabled: true },
-              fontSize: 14,
-              lineNumbers: 'on',
-              wordWrap: 'on',
+              minimap: { enabled: editorSettings.minimap },
+              fontSize: editorSettings.fontSize,
+              lineNumbers: editorSettings.lineNumbers ? 'on' : 'off',
+              wordWrap: editorSettings.wordWrap ? 'on' : 'off',
               scrollBeyondLastLine: false,
               folding: true,
               renderLineHighlight: 'line',
-              tabSize: 4,
+              tabSize: editorSettings.tabSize,
               insertSpaces: true,
               automaticLayout: true,
               formatOnPaste: true,
-              formatOnType: true,
-              quickSuggestions: true,
+              // Suppress completion pop-ups inside strings and comments so typing
+              // prose (e.g. a Cyrillic log message) is not interrupted by the
+              // activity/library suggestion list.
+              quickSuggestions: { other: true, comments: false, strings: false },
               suggestOnTriggerCharacters: true,
               acceptSuggestionOnEnter: 'on',
               tabCompletion: 'on',
@@ -365,8 +443,22 @@ const PythonCodeEditor: React.FC<PythonCodeEditorProps> = ({
           isSaved={!isDirty}
           errors={validationErrors.length}
           warnings={validationWarnings.length}
+          onNextProblem={handleNextProblem}
         />
       </div>
+
+      <ConfirmDialog
+        open={showDiscardConfirm}
+        title={t('codeEditor.editor.unsavedTitle')}
+        message={t('codeEditor.editor.unsavedMessage')}
+        confirmLabel={t('codeEditor.editor.discard')}
+        destructive
+        onConfirm={() => {
+          setShowDiscardConfirm(false);
+          onClose();
+        }}
+        onCancel={() => setShowDiscardConfirm(false)}
+      />
     </div>
   );
 };

--- a/packages/studio/src/hooks/useFocusTrap.ts
+++ b/packages/studio/src/hooks/useFocusTrap.ts
@@ -29,6 +29,14 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(isOpen: boolea
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Tab' || !containerRef.current) return;
 
+      // Let an embedded Monaco editor own Tab navigation within its own widgets
+      // (find/replace inputs, suggestions). Trapping Tab globally fights Monaco's
+      // internal focus management and can wedge the find widget.
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && active.closest('.monaco-editor')) {
+        return;
+      }
+
       const focusable = getFocusableElements();
       if (focusable.length === 0) {
         event.preventDefault();

--- a/packages/studio/src/i18n/types/resources.d.ts
+++ b/packages/studio/src/i18n/types/resources.d.ts
@@ -845,6 +845,25 @@ declare module 'i18next' {
           descriptionPlaceholder: string;
         };
         codeEditor: {
+          editor: {
+            title: string;
+            save: string;
+            saveHint: string;
+            apply: string;
+            applyHint: string;
+            cancel: string;
+            maximize: string;
+            restore: string;
+            formatHint: string;
+            formatOnSave: string;
+            nextProblem: string;
+            saved: string;
+            modified: string;
+            unsavedTitle: string;
+            unsavedMessage: string;
+            discard: string;
+            keepEditing: string;
+          };
           variablesPanel: {
             searchPlaceholder: string;
             addVariablesHint: string;

--- a/packages/studio/src/index.css
+++ b/packages/studio/src/index.css
@@ -444,3 +444,16 @@ body {
 .console-output {
   @apply font-mono text-sm bg-slate-900 text-slate-100 p-3 rounded overflow-auto;
 }
+
+/*
+ * Monaco action-button tooltips (e.g. the find/replace widget's
+ * "Close (Escape)" and "Find in Selection (Alt+L)") render their text with an
+ * inline `white-space: pre-wrap` in a narrow box, so the label wraps to a
+ * second line that overlaps the button beneath it and blocks the click. These
+ * simple tooltips carry the `compact` class (rich code hovers do not), so we can
+ * keep just them on a single line. `!important` is required to beat the inline
+ * style on `.hover-contents`.
+ */
+.monaco-hover.workbench-hover.compact .hover-contents {
+  white-space: nowrap !important;
+}

--- a/packages/studio/src/stores/settingsStore.ts
+++ b/packages/studio/src/stores/settingsStore.ts
@@ -27,6 +27,7 @@ export interface EditorSettings {
   wordWrap: boolean;
   minimap: boolean;
   lineNumbers: boolean;
+  formatOnSave: boolean;
 }
 
 export interface DesignerSettings {
@@ -94,6 +95,7 @@ export const useSettingsStore = create<SettingsState>()(
         wordWrap: true,
         minimap: false,
         lineNumbers: true,
+        formatOnSave: false,
       },
 
       designer: {


### PR DESCRIPTION
## Summary

Twelve usability improvements to the Monaco code editor modal (`PythonCodeEditor`), opened from activity parameters.

| # | Improvement |
|---|---|
| 1 | **Unsaved-changes guard** — Escape/Cancel confirm before discarding a dirty buffer (reuses `ConfirmDialog`). |
| 2 | **Quieter completions** — no suggestion pop-ups inside strings/comments; list filters by typed prefix instead of dumping all activities. |
| 3 | **Editor settings respected** — font size, tab size, word wrap, minimap, line numbers come from `settingsStore`. |
| 4 | **i18n** — modal title, Save/Apply/Cancel, Maximize/Restore, status, confirm dialog (en + ru; others fall back to en). |
| 5 | **Signature help** — parameter hints for activity calls. |
| 6 | **Problems navigation** — clickable error/warning counts jump to next marker. |
| 7 | **Accessibility** — `role=dialog`, `aria-modal`, `aria-label`, focus trap. |
| 8 | **Shortcut hints** in button tooltips (Save Ctrl+S, Format Ctrl+Shift+F). |
| 9 | Removed no-op `formatOnType` (no Python on-type formatter). |
| 10 | **Format-on-save** toggle (header checkbox, persisted in settings). |
| 11 | **Apply** button saves without closing. |
| 12 | Minimap now follows the user setting (was always on). |

## Verification

- `tsc --noEmit` ✅
- `eslint` on changed files ✅ (also voided pre-existing floating-promise calls in touched files)
- `vitest run` ✅ 162/162

## Notes

- New i18n keys added under `codeEditor.editor` to `en`/`ru` and to the strict `resources.d.ts` types; `de`/`es`/`zh` fall back to `en` (consistent with the existing partial `codeEditor` coverage).
- `formatOnSave` added to `EditorSettings` (default `false`).