### PR TITLE
test(studio): add packaged Electron E2E smoke suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,18 +148,6 @@ jobs:
         with:
           version: 11
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.11"
-
-      - name: Install engine build tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install pyinstaller
-          pip install ./packages/core
-          pip install "./packages/libraries[desktop,web,excel,database,keystore,dataframes]"
-
       # Install all JS/TS dependencies declared in packages/studio/package.json
       # and the workspace root.
       - name: Install dependencies
@@ -194,6 +182,18 @@ jobs:
         uses: pnpm/action-setup@v5
         with:
           version: 11
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install engine build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install ./packages/core
+          pip install "./packages/libraries[desktop,web,excel,database,keystore,dataframes]"
 
       - name: Install dependencies
         working-directory: packages/studio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,18 @@ jobs:
         with:
           version: 11
 
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install engine build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller
+          pip install ./packages/core
+          pip install "./packages/libraries[desktop,web,excel,database,keystore,dataframes]"
+
       # Install all JS/TS dependencies declared in packages/studio/package.json
       # and the workspace root.
       - name: Install dependencies
@@ -187,9 +199,26 @@ jobs:
         working-directory: packages/studio
         run: pnpm install
 
+      - name: Build Python bridge
+        working-directory: packages/studio
+        run: pnpm build:bridge
+
       - name: Build Electron app
         working-directory: packages/studio
         run: pnpm build
+
+      - name: Run packaged Electron E2E smoke suite
+        working-directory: packages/studio
+        run: pnpm test:e2e
+
+      - name: Upload Electron E2E artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-e2e-failure-artifacts
+          path: |
+            packages/studio/test-results
+            packages/studio/playwright-report
 
       - name: Upload installer artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -193,6 +193,10 @@ package-lock.json
 # Playwright MCP
 .playwright-mcp/
 
+# Packaged Electron E2E output
+packages/studio/playwright-report/
+packages/studio/test-results/
+
 # Debug/dev artifacts
 *_debug.txt
 check_dev.txt

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -24,12 +24,15 @@ engine = StudioEngine()
 engine.executor.register_library("DesktopUI", DesktopUI())
 
 builder = engine.create_process("Notepad Automation")
-builder.add_task("Open and Type", [
-    ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
-    ("DesktopUI.Wait For Window",  {"title": "Notepad", "timeout": "10s"}),
-    ("DesktopUI.Input Text",       {"text": "Hello from RPAForge!"}),
-    ("DesktopUI.Close Window",     {}),
-])
+builder.add_task(
+    "Open and Type",
+    [
+        ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
+        ("DesktopUI.Wait For Window", {"title": "Notepad", "timeout": "10s"}),
+        ("DesktopUI.Input Text", {"text": "Hello from RPAForge!"}),
+        ("DesktopUI.Close Window", {}),
+    ],
+)
 
 result = engine.run(builder.build())
 print(f"Status: {result.status}")

--- a/packages/core/README.ru.md
+++ b/packages/core/README.ru.md
@@ -24,12 +24,15 @@ engine = StudioEngine()
 engine.executor.register_library("DesktopUI", DesktopUI())
 
 builder = engine.create_process("Notepad Automation")
-builder.add_task("Open and Type", [
-    ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
-    ("DesktopUI.Wait For Window",  {"title": "Notepad", "timeout": "10s"}),
-    ("DesktopUI.Input Text",       {"text": "Hello from RPAForge!"}),
-    ("DesktopUI.Close Window",     {}),
-])
+builder.add_task(
+    "Open and Type",
+    [
+        ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
+        ("DesktopUI.Wait For Window", {"title": "Notepad", "timeout": "10s"}),
+        ("DesktopUI.Input Text", {"text": "Hello from RPAForge!"}),
+        ("DesktopUI.Close Window", {}),
+    ],
+)
 
 result = engine.run(builder.build())
 print(f"Status: {result.status}")

--- a/packages/core/src/rpaforge/bridge/__main__.py
+++ b/packages/core/src/rpaforge/bridge/__main__.py
@@ -4,5 +4,7 @@ from rpaforge.bridge.server import main
 
 if __name__ == "__main__":
     import asyncio
+    import multiprocessing
 
+    multiprocessing.freeze_support()
     asyncio.run(main())

--- a/packages/core/src/rpaforge/bridge/server.py
+++ b/packages/core/src/rpaforge/bridge/server.py
@@ -351,6 +351,7 @@ class BridgeServer:
 
 async def main() -> None:
     """Main entry point for the bridge server."""
+    engine = None
     try:
         from rpaforge import StudioEngine
 
@@ -373,6 +374,9 @@ async def main() -> None:
         )
         sys.stderr.flush()
         raise
+    finally:
+        if engine is not None:
+            engine.close()
 
 
 if __name__ == "__main__":

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -631,6 +631,12 @@ class StudioEngine:
     def stop(self) -> None:
         self._runner.stop()
 
+    def close(self) -> None:
+        """Release executor resources owned by the engine."""
+        close = getattr(self._runner.executor, "close", None)
+        if callable(close):
+            close()
+
     def clear_checkpoint(self) -> bool:
         return self._runner.clear_checkpoint()
 

--- a/packages/core/tests/test_bridge_server.py
+++ b/packages/core/tests/test_bridge_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import runpy
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -403,6 +404,16 @@ class TestBridgeServerMain:
 
                 mock_engine_class.assert_called_once()
                 mock_start.assert_called_once()
+                mock_engine.close.assert_called_once()
+
+    def test_bridge_entrypoint_enables_multiprocessing_bootstrap(self):
+        """Test the frozen bridge initializes multiprocessing support."""
+        with patch("multiprocessing.freeze_support") as mock_freeze_support:
+            with patch("asyncio.run") as mock_asyncio_run:
+                runpy.run_module("rpaforge.bridge.__main__", run_name="__main__")
+
+                mock_freeze_support.assert_called_once()
+                mock_asyncio_run.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_main_error(self):

--- a/packages/core/tests/test_engine.py
+++ b/packages/core/tests/test_engine.py
@@ -1,5 +1,7 @@
 """Tests for RPAForge Core Engine."""
 
+from unittest.mock import MagicMock
+
 from rpaforge.core.execution import (
     ActivityCall,
     Process,
@@ -30,6 +32,14 @@ class TestStudioEngine:
         engine.stop()
 
         assert engine.stop_requested is True
+
+    def test_close_releases_executor_resources(self):
+        executor = MagicMock()
+        engine = StudioEngine(executor=executor)
+
+        engine.close()
+
+        executor.close.assert_called_once()
 
     def test_cancel_process(self):
         engine = StudioEngine()

--- a/packages/studio/e2e/electron-smoke.spec.ts
+++ b/packages/studio/e2e/electron-smoke.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test } from '@playwright/test';
+import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const studioDir = path.resolve(import.meta.dirname, '..');
+
+function resolvePackagedExecutable(): string {
+  const configuredPath = process.env.RPAFORGE_ELECTRON_EXECUTABLE;
+  const candidates = configuredPath
+    ? [configuredPath]
+    : process.platform === 'win32'
+      ? [path.join(studioDir, 'dist-electron', 'win-unpacked', 'RPAForge Studio.exe')]
+      : process.platform === 'darwin'
+        ? [path.join(studioDir, 'dist-electron', 'mac', 'RPAForge Studio.app', 'Contents', 'MacOS', 'RPAForge Studio')]
+        : [path.join(studioDir, 'dist-electron', 'linux-unpacked', 'rpaforge-studio')];
+
+  const executable = candidates.find((candidate) => existsSync(candidate));
+  if (!executable) {
+    throw new Error(
+      `Packaged Electron executable not found. Run "pnpm build" first or set RPAFORGE_ELECTRON_EXECUTABLE. Tried: ${candidates.join(', ')}`
+    );
+  }
+  return executable;
+}
+
+async function closeElectron(app: ElectronApplication | undefined): Promise<void> {
+  if (!app) return;
+  await app.close().catch(() => undefined);
+}
+
+async function removeTempDirectory(directory: string): Promise<void> {
+  await Promise.race([
+    rm(directory, { recursive: true, force: true, maxRetries: 10, retryDelay: 500 }),
+    new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
+  ]);
+}
+
+test('launches the production Electron app and completes an IPC file round-trip', async () => {
+  const executable = resolvePackagedExecutable();
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'rpaforge-electron-e2e-'));
+  const userDataRoot = await mkdtemp(path.join(os.tmpdir(), 'rpaforge-electron-user-data-'));
+  let app: ElectronApplication | undefined;
+
+  try {
+    app = await electron.launch({
+      executablePath: executable,
+      args: [`--user-data-dir=${userDataRoot}`],
+      env: {
+        ...process.env,
+        ELECTRON_ENABLE_LOGGING: '1',
+      },
+    });
+
+    const page: Page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page).toHaveTitle(/RPAForge Studio/i);
+    await expect(page.getByRole('heading', { name: 'Welcome to RPAForge' })).toBeVisible();
+
+    const apiSurface = await page.evaluate(async () => {
+      const api = window.rpaforge;
+      return {
+        keys: api ? Object.keys(api) : [],
+        bridgeStatus: api ? await api.bridge.getStatus() : null,
+      };
+    });
+
+    expect(apiSurface.keys).toEqual(expect.arrayContaining(['bridge', 'engine', 'fs']));
+    expect(apiSurface.bridgeStatus?.state).toBeTruthy();
+
+    await expect
+      .poll(
+        () => page.evaluate(() => window.rpaforge?.bridge.getStatus()),
+        { timeout: 75_000, message: 'Bundled Python bridge did not become operational' }
+      )
+      .toMatchObject({ isOperational: true });
+    console.log('Packaged bridge is operational');
+
+    const projectRoot = path.join(tempRoot, 'project');
+    const projectFile = path.join(projectRoot, 'project.json');
+    const projectContent = JSON.stringify({ name: 'Electron E2E Project', version: '1.0.0' });
+    const roundTrip = await page.evaluate(
+      async ({ root, file, content }) => {
+        const api = window.rpaforge;
+        if (!api) throw new Error('RPAForge preload API is unavailable');
+        await api.fs.setProjectRoot(root);
+        await api.fs.writeFile(file, content);
+        return {
+          exists: await api.fs.pathExists(file),
+          content: await api.fs.readFile(file),
+        };
+      },
+      { root: projectRoot, file: projectFile, content: projectContent }
+    );
+    console.log('IPC file round-trip completed');
+
+    expect(roundTrip).toEqual({ exists: true, content: projectContent });
+  } finally {
+    console.log('Closing packaged Electron app');
+    await closeElectron(app);
+    console.log('Packaged Electron app closed');
+    await removeTempDirectory(tempRoot);
+    await removeTempDirectory(userDataRoot);
+    console.log('Temporary E2E project removed');
+  }
+});

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "test:coverage": "vitest --coverage",
     "electron:dev": "vite",
     "electron:build": "vite build && electron-builder",
@@ -65,6 +66,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",
+    "playwright": "^1.60.0",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.2",

--- a/packages/studio/playwright.config.ts
+++ b/packages/studio/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 120_000,
+  expect: {
+    timeout: 15_000,
+  },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }],
+  ],
+  use: {
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  outputDir: 'test-results',
+});

--- a/packages/studio/vitest.config.ts
+++ b/packages/studio/vitest.config.ts
@@ -13,6 +13,6 @@ export default defineConfig({
     environment: 'happy-dom',
     globals: true,
     setupFiles: ['./src/setupTests.tsx'],
-    exclude: ['dist/**', 'dist-electron/**', 'release/**', 'node_modules/**'],
+    exclude: ['dist/**', 'dist-electron/**', 'release/**', 'node_modules/**', 'e2e/**'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       lint-staged:
         specifier: ^17.0.6
         version: 17.0.8
+      playwright:
+        specifier: ^1.60.0
+        version: 1.61.1
       rollup:
         specifier: ^4.60.4
         version: 4.62.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 overrides:
   dompurify: '>=3.4.11'
   form-data: '>=4.0.6'
+  brace-expansion: '>=5.0.8'
+  fast-uri: '>=3.1.4'
+  postcss: '>=8.5.18'
   undici: '>=7.28.0'
   vite: '>=8.0.16'
 
@@ -1592,9 +1595,6 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1617,15 +1617,9 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -1756,9 +1750,6 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2298,8 +2289,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
@@ -2962,8 +2953,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3111,8 +3102,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.22:
+    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -5170,7 +5161,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5266,8 +5257,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -5283,16 +5272,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5430,8 +5410,6 @@ snapshots:
       dot-prop: 5.3.0
 
   compare-version@0.1.2: {}
-
-  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -6046,7 +6024,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@4.1.1: {}
 
   fault@1.0.4:
     dependencies:
@@ -6670,19 +6648,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 5.0.8
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -6712,7 +6690,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6870,9 +6848,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.16:
+  postcss@8.5.22:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7473,7 +7451,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.22
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,9 @@ packages:
 overrides:
   dompurify: '>=3.4.11'
   form-data: '>=4.0.6'
+  brace-expansion: '>=5.0.8'
+  fast-uri: '>=3.1.4'
+  postcss: '>=8.5.18'
   undici: '>=7.28.0'
   vite: '>=8.0.16'
 


### PR DESCRIPTION
Closes #637\n\nAdds a Playwright packaged Electron smoke test that launches win-unpacked, verifies preload APIs and bundled Python bridge readiness, and round-trips an isolated project file through IPC. CI now builds the Python bridge before Electron packaging and uploads Playwright artifacts on failure.\n\nLocal verification: core 486 passed; Studio 493 passed; TypeScript; Ruff; packaged Electron E2E 1 passed.