### PR TITLE
perf(studio): lazy-load secondary tools and enforce bundle budget

### DIFF
--- a/packages/studio/docs/bundle-budget.md
+++ b/packages/studio/docs/bundle-budget.md
@@ -1,0 +1,20 @@
+# Studio renderer bundle budget
+
+The renderer build is measured from the uncompressed files in `dist/assets`.
+`pnpm build` runs `check:bundle` immediately after Vite produces the renderer,
+so the Electron packaging job fails when a budget regresses.
+
+Baseline on 2026-07-25 before lazy-loading secondary tools:
+
+- Renderer entry: 4,065 KB
+- Largest JavaScript chunk: 663 KB
+- Largest stylesheet: 116 KB
+
+Current limits:
+
+- Renderer entry: 3,500 KB
+- Largest JavaScript chunk: 1,500 KB
+- Largest stylesheet: 140 KB
+
+The entry budget protects startup evaluation. The chunk and stylesheet budgets
+protect major interaction payloads without preventing intentional small chunks.

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -6,9 +6,10 @@
   "main": "dist-electron/electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && electron-builder",
+    "build": "pnpm build:renderer && electron-builder",
+    "build:renderer": "vite build && pnpm check:bundle",
     "build:bridge": "node scripts/build-bridge.mjs",
-    "build:dist": "node scripts/build-bridge.mjs && vite build && electron-builder",
+    "build:dist": "node scripts/build-bridge.mjs && pnpm build:renderer && electron-builder",
     "preview": "vite preview",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
@@ -16,7 +17,8 @@
     "test:e2e": "playwright test",
     "test:coverage": "vitest --coverage",
     "electron:dev": "vite",
-    "electron:build": "vite build && electron-builder",
+    "electron:build": "pnpm build:renderer && electron-builder",
+    "check:bundle": "node scripts/check-bundle-size.mjs",
     "i18n:extract": "i18next-scanner --config i18next-scanner.config.cjs"
   },
   "keywords": [

--- a/packages/studio/public/locales/de/common.json
+++ b/packages/studio/public/locales/de/common.json
@@ -1180,6 +1180,11 @@
   "inlineLoading": {
     "loading": "Laden..."
   },
+  "lazyFeature": {
+    "loading": "Funktion wird geladen...",
+    "error": "Diese Funktion konnte nicht geladen werden.",
+    "retry": "Erneut versuchen"
+  },
   "fieldHelp": {
     "helpFor": "Hilfe für {{title}}",
     "format": "Format:",

--- a/packages/studio/public/locales/en/common.json
+++ b/packages/studio/public/locales/en/common.json
@@ -1214,6 +1214,11 @@
   "inlineLoading": {
     "loading": "Loading..."
   },
+  "lazyFeature": {
+    "loading": "Loading feature...",
+    "error": "This feature could not be loaded.",
+    "retry": "Try again"
+  },
   "fieldHelp": {
     "helpFor": "Help for {{title}}",
     "format": "Format:",

--- a/packages/studio/public/locales/es/common.json
+++ b/packages/studio/public/locales/es/common.json
@@ -1179,6 +1179,11 @@
   "inlineLoading": {
     "loading": "Cargando..."
   },
+  "lazyFeature": {
+    "loading": "Cargando función...",
+    "error": "No se pudo cargar esta función.",
+    "retry": "Intentar de nuevo"
+  },
   "fieldHelp": {
     "helpFor": "Ayuda para {{title}}",
     "format": "Formato:",

--- a/packages/studio/public/locales/ru/common.json
+++ b/packages/studio/public/locales/ru/common.json
@@ -1395,6 +1395,11 @@
   "inlineLoading": {
     "loading": "Загрузка..."
   },
+  "lazyFeature": {
+    "loading": "Загрузка функции...",
+    "error": "Не удалось загрузить эту функцию.",
+    "retry": "Повторить"
+  },
   "variablesPanel_noVariables": "Нет переменных",
   "variablesPanel_processVariables": "Переменные процесса",
   "variablesPanel_taskVariables": "Переменные задачи",

--- a/packages/studio/public/locales/zh/common.json
+++ b/packages/studio/public/locales/zh/common.json
@@ -1180,6 +1180,11 @@
   "inlineLoading": {
     "loading": "加载中..."
   },
+  "lazyFeature": {
+    "loading": "正在加载功能...",
+    "error": "无法加载此功能。",
+    "retry": "重试"
+  },
   "fieldHelp": {
     "helpFor": "{{title}} 的帮助",
     "format": "格式：",

--- a/packages/studio/scripts/check-bundle-size.mjs
+++ b/packages/studio/scripts/check-bundle-size.mjs
@@ -1,0 +1,71 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = fileURLToPath(new URL('../dist', import.meta.url));
+const BUDGETS = {
+  entryBytes: 3_500_000,
+  largestJavaScriptBytes: 1_500_000,
+  stylesheetBytes: 140_000,
+};
+
+async function collectFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(filePath)));
+    } else {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+const files = await collectFiles(DIST_DIR);
+const assets = files.filter((filePath) => filePath.includes(`${path.sep}assets${path.sep}`));
+const javascript = assets.filter((filePath) => filePath.endsWith('.js'));
+const stylesheets = assets.filter((filePath) => filePath.endsWith('.css'));
+const entry = javascript.find((filePath) => path.basename(filePath).startsWith('index-'));
+
+if (!entry) {
+  throw new Error('Renderer bundle entry was not found in dist/assets.');
+}
+
+const sizes = await Promise.all(
+  assets.map(async (filePath) => ({
+    filePath,
+    bytes: (await stat(filePath)).size,
+  }))
+);
+const sizeByPath = new Map(sizes.map((asset) => [asset.filePath, asset.bytes]));
+const entryBytes = sizeByPath.get(entry);
+const secondaryJavaScript = javascript.filter((filePath) => filePath !== entry);
+const largestJavaScriptBytes = Math.max(...secondaryJavaScript.map((filePath) => sizeByPath.get(filePath)), 0);
+const stylesheetBytes = Math.max(...stylesheets.map((filePath) => sizeByPath.get(filePath)), 0);
+
+console.log(`Renderer entry: ${formatBytes(entryBytes)} / ${formatBytes(BUDGETS.entryBytes)}`);
+console.log(`Largest JavaScript chunk: ${formatBytes(largestJavaScriptBytes)} / ${formatBytes(BUDGETS.largestJavaScriptBytes)}`);
+console.log(`Largest stylesheet: ${formatBytes(stylesheetBytes)} / ${formatBytes(BUDGETS.stylesheetBytes)}`);
+
+const violations = [];
+if (entryBytes > BUDGETS.entryBytes) {
+  violations.push(`renderer entry exceeds ${formatBytes(BUDGETS.entryBytes)}`);
+}
+if (largestJavaScriptBytes > BUDGETS.largestJavaScriptBytes) {
+  violations.push(`a JavaScript chunk exceeds ${formatBytes(BUDGETS.largestJavaScriptBytes)}`);
+}
+if (stylesheetBytes > BUDGETS.stylesheetBytes) {
+  violations.push(`a stylesheet exceeds ${formatBytes(BUDGETS.stylesheetBytes)}`);
+}
+
+if (violations.length > 0) {
+  throw new Error(`Renderer bundle budget exceeded: ${violations.join('; ')}`);
+}

--- a/packages/studio/src/canvas/autoLayout.ts
+++ b/packages/studio/src/canvas/autoLayout.ts
@@ -13,7 +13,6 @@
  * so a swapped subtree order makes the wires visibly cross at the source.
  */
 
-import ELK from 'elkjs/lib/elk.bundled.js';
 import type { Node, Edge } from '@xyflow/react';
 import type { ProcessNodeData } from '../stores/blockStore';
 import {
@@ -24,8 +23,6 @@ import {
   type BlockPortConfig,
   type Port,
 } from '../types/blocks';
-
-const elk = new ELK();
 
 // Fallback size for nodes without a `measured` size yet (mirrors BaseBlock.tsx:
 // HEADER_HEIGHT 34 + MIN_CONTENT_HEIGHT 50 + PORT_LABELS_AREA 20, BASE_MIN_WIDTH 200).
@@ -140,6 +137,9 @@ export async function computeAutoLayout(
   if (nodes.length === 0) {
     return [];
   }
+
+  const { default: ELK } = await import('elkjs/lib/elk.bundled.js');
+  const elk = new ELK();
 
   // Collect pinned node positions so we can restore them after ELK runs.
   // Pinned nodes are still included in the ELK graph (with their current x/y

--- a/packages/studio/src/canvas/loadAutoLayout.ts
+++ b/packages/studio/src/canvas/loadAutoLayout.ts
@@ -1,0 +1,11 @@
+import type { Edge, Node } from '@xyflow/react';
+import type { ProcessNodeData } from '../stores/blockStore';
+import type { LayoutedPosition } from './autoLayout';
+
+export async function computeAutoLayout(
+  nodes: Node<ProcessNodeData>[],
+  edges: Edge[]
+): Promise<LayoutedPosition[]> {
+  const { computeAutoLayout: loadLayout } = await import('./autoLayout');
+  return loadLayout(nodes, edges);
+}

--- a/packages/studio/src/components/Common/FileMenu.tsx
+++ b/packages/studio/src/components/Common/FileMenu.tsx
@@ -54,11 +54,14 @@ import { MarketplaceDialog } from './MarketplaceDialog';
 import AiPromptLibrary from './AiPromptLibrary';
 import AiCompareDialog from './AiCompareDialog';
 import SettingsDialog from './SettingsDialog';
-import HelpDialog from './HelpDialog';
+import { lazy } from 'react';
+import { LazyFeature } from './LazyFeature';
 import SecurityAuditDialog from './SecurityAuditDialog';
 import { readFileAsText } from '../../utils/fileUtils';
 import type { ProcessNode } from '../../stores/blockStore';
 import type { AiProviderId } from '../../types/ai';
+
+const HelpDialog = lazy(() => import('./HelpDialog'));
 
 const getTemplateIcon = (iconName: string): React.ReactNode => {
   switch (iconName) {
@@ -1449,7 +1452,11 @@ const FileMenu: React.FC<FileMenuProps> = ({
       )}
 
       <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
-      <HelpDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
+      {showShortcuts && (
+        <LazyFeature>
+          <HelpDialog open onClose={() => setShowShortcuts(false)} />
+        </LazyFeature>
+      )}
       <SecurityAuditDialog open={showSecurityAudit} onClose={() => setShowSecurityAudit(false)} />
     </>
   );

--- a/packages/studio/src/components/Common/LazyFeature.test.tsx
+++ b/packages/studio/src/components/Common/LazyFeature.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { LazyFeature } from './LazyFeature';
+
+let shouldThrow = true;
+
+function UnstableFeature() {
+  if (shouldThrow) {
+    throw new Error('feature chunk unavailable');
+  }
+
+  return <div>feature loaded</div>;
+}
+
+describe('LazyFeature', () => {
+  beforeEach(() => {
+    shouldThrow = true;
+  });
+
+  test('offers a retry after a feature error', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    render(
+      <LazyFeature>
+        <UnstableFeature />
+      </LazyFeature>
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('lazyFeature.error');
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'lazyFeature.retry' }));
+
+    expect(screen.getByText('feature loaded')).toBeTruthy();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/studio/src/components/Common/LazyFeature.tsx
+++ b/packages/studio/src/components/Common/LazyFeature.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import { Suspense } from 'react';
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
+import { useTranslation } from 'react-i18next';
+
+interface LazyFeatureProps {
+  children: ReactNode;
+}
+
+function LazyFeatureFallback({ resetErrorBoundary }: FallbackProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      className="flex items-center justify-center gap-3 p-4 text-sm text-ui-text-muted"
+      role="alert"
+      aria-live="assertive"
+    >
+      <span>{t('lazyFeature.error')}</span>
+      <button
+        type="button"
+        className="rounded bg-ui-primary px-3 py-1.5 text-ui-text-inverse hover:bg-ui-primary-hover"
+        onClick={resetErrorBoundary}
+      >
+        {t('lazyFeature.retry')}
+      </button>
+    </div>
+  );
+}
+
+export function LazyFeatureLoading() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      className="flex min-h-16 items-center justify-center p-4 text-sm text-ui-text-muted"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      {t('lazyFeature.loading')}
+    </div>
+  );
+}
+
+export function LazyFeature({ children }: LazyFeatureProps) {
+  return (
+    <ErrorBoundary FallbackComponent={LazyFeatureFallback}>
+      <Suspense fallback={<LazyFeatureLoading />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/packages/studio/src/components/Designer/EditableTextField.tsx
+++ b/packages/studio/src/components/Designer/EditableTextField.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiMoreHorizontal } from 'react-icons/fi';
-import PythonCodeEditor from './PythonCodeEditor';
+import PythonCodeEditor from './LazyPythonCodeEditor';
 
 interface EditableTextFieldProps {
   value: string;

--- a/packages/studio/src/components/Designer/ExpressionEditor.tsx
+++ b/packages/studio/src/components/Designer/ExpressionEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { FiPlus, FiMoreHorizontal, FiAlertCircle, FiCheckCircle, FiHelpCircle, FiX } from 'react-icons/fi';
 import type { VariableInfo } from './VariablePicker';
-import PythonCodeEditor from './PythonCodeEditor';
+import PythonCodeEditor from './LazyPythonCodeEditor';
 
 export interface ValidationResult {
   isValid: boolean;

--- a/packages/studio/src/components/Designer/LazyPythonCodeEditor.tsx
+++ b/packages/studio/src/components/Designer/LazyPythonCodeEditor.tsx
@@ -1,0 +1,17 @@
+import { lazy } from 'react';
+import type { ComponentProps } from 'react';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const PythonCodeEditor = lazy(() => import('./PythonCodeEditor'));
+
+type LazyPythonCodeEditorProps = ComponentProps<typeof PythonCodeEditor>;
+
+export default function LazyPythonCodeEditor(props: LazyPythonCodeEditorProps) {
+  if (!props.isOpen) return null;
+
+  return (
+    <LazyFeature>
+      <PythonCodeEditor {...props} />
+    </LazyFeature>
+  );
+}

--- a/packages/studio/src/components/Designer/ProcessCanvas.tsx
+++ b/packages/studio/src/components/Designer/ProcessCanvas.tsx
@@ -21,7 +21,7 @@ import {
   useViewport,
 } from '@xyflow/react';
 import { createActivityBlockData, type BlockData } from '../../types/blocks';
-import { computeAutoLayout } from '../../canvas/autoLayout';
+import { computeAutoLayout } from '../../canvas/loadAutoLayout';
 import { edgeTypes } from './Edges';
 import { ConnectionLine } from './Edges/ConnectionLine';
 import { blockNodeTypes } from './Blocks';

--- a/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
+++ b/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
@@ -6,7 +6,7 @@ import { getActivityDisplayLibrary, type Activity } from '../../../domain/activi
 import { getLibraryNamespace, getActivityKey } from '../../../utils/activityI18n';
 
 import VariableDialog, { type VariableDefinition } from '../VariableDialog';
-import PythonCodeEditor from '../PythonCodeEditor';
+import PythonCodeEditor from '../LazyPythonCodeEditor';
 import ParameterMappingDialog from '../ParameterMappingDialog';
 import DiagramSettingsDialog from '../DiagramSettingsDialog';
 import WorkflowStatisticsPanel from '../WorkflowStatisticsPanel';

--- a/packages/studio/src/components/Layout/Layout.tsx
+++ b/packages/studio/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { lazy, useState, useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
@@ -24,14 +24,16 @@ import ActivityPaletteSidebar from './ActivityPaletteSidebar';
 import PropertiesSidebar from './PropertiesSidebar';
 import MainContent from './MainContent';
 import StatusBar from './StatusBar';
-import CodeModal from './CodeModal';
 import ConfirmDialog from '../Common/ConfirmDialog';
 import { LoadingOverlay } from '../Common/Loading';
-import { MermaidPreview } from '../Common/MermaidPreview';
-import HelpDialog from '../Common/HelpDialog';
-import { WelcomeScreen } from '../Common/WelcomeScreen';
-import { OnboardingTour } from '../Common/OnboardingTour';
-import LibraryBrowser from '../LibraryBrowser/LibraryBrowser';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const CodeModal = lazy(() => import('./CodeModal'));
+const MermaidPreview = lazy(() => import('../Common/MermaidPreview'));
+const HelpDialog = lazy(() => import('../Common/HelpDialog'));
+const WelcomeScreen = lazy(() => import('../Common/WelcomeScreen').then(({ WelcomeScreen: component }) => ({ default: component })));
+const OnboardingTour = lazy(() => import('../Common/OnboardingTour'));
+const LibraryBrowser = lazy(() => import('../LibraryBrowser/LibraryBrowser'));
 
 const Layout: React.FC = () => {
   const { t } = useTranslation('common');
@@ -532,22 +534,30 @@ const Layout: React.FC = () => {
         onRestartBridge={() => { void window.rpaforge?.bridge.restart(); }}
       />
 
-      <CodeModal
-        isOpen={showCodeModal}
-        code={generatedCode}
-        files={generatedFiles}
-        fileCount={generatedFiles ? Object.keys(generatedFiles).length : 0}
-        onClose={handleCloseCodeModal}
-        onDownload={handleDownloadCode}
-      />
+      {showCodeModal && (
+        <LazyFeature>
+          <CodeModal
+            isOpen
+            code={generatedCode}
+            files={generatedFiles}
+            fileCount={generatedFiles ? Object.keys(generatedFiles).length : 0}
+            onClose={handleCloseCodeModal}
+            onDownload={handleDownloadCode}
+          />
+        </LazyFeature>
+      )}
 
-      <MermaidPreview
-        isOpen={showMermaidPreview}
-        onClose={() => setShowMermaidPreview(false)}
-        nodes={nodes}
-        edges={edges}
-        title={metadata?.name || t('layout.processDiagram')}
-      />
+      {showMermaidPreview && (
+        <LazyFeature>
+          <MermaidPreview
+            isOpen
+            onClose={() => setShowMermaidPreview(false)}
+            nodes={nodes}
+            edges={edges}
+            title={metadata?.name || t('layout.processDiagram')}
+          />
+        </LazyFeature>
+      )}
 
       <LoadingOverlay isVisible={loading.execute || loading.open} message={loadingMessage || t('layout.executing')} progress={executionProgress > 0 ? executionProgress : undefined} />
 
@@ -571,7 +581,11 @@ const Layout: React.FC = () => {
         onCancel={() => setStatefulDialog(null)}
       />
 
-      <HelpDialog open={showHelp} onClose={() => setShowHelp(false)} />
+      {showHelp && (
+        <LazyFeature>
+          <HelpDialog open onClose={() => setShowHelp(false)} />
+        </LazyFeature>
+      )}
 
       {showLibraryBrowser && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -586,26 +600,34 @@ const Layout: React.FC = () => {
               </button>
             </div>
             <div className="flex-1 overflow-y-auto">
-              <LibraryBrowser />
+              <LazyFeature>
+                <LibraryBrowser />
+              </LazyFeature>
             </div>
           </div>
         </div>
       )}
 
       {showWelcome && !project && (
-        <WelcomeScreen
-          onNewProcess={() => newProject('New Project')}
-          onOpenProcess={() => void handleOpenProject()}
-          onDismiss={() => setShowWelcome(false)}
-          onImportMermaid={handleShowMermaid}
-          onBrowseLibraries={() => setShowLibraryBrowser(true)}
-          onGettingStarted={() => {
-            setShowWelcome(false);
-          }}
-        />
+        <LazyFeature>
+          <WelcomeScreen
+            onNewProcess={() => newProject('New Project')}
+            onOpenProcess={() => void handleOpenProject()}
+            onDismiss={() => setShowWelcome(false)}
+            onImportMermaid={handleShowMermaid}
+            onBrowseLibraries={() => setShowLibraryBrowser(true)}
+            onGettingStarted={() => {
+              setShowWelcome(false);
+            }}
+          />
+        </LazyFeature>
       )}
 
-      <OnboardingTour />
+      {!isInitializing && (
+        <LazyFeature>
+          <OnboardingTour />
+        </LazyFeature>
+      )}
     </div>
   );
 };

--- a/packages/studio/src/components/Layout/index.ts
+++ b/packages/studio/src/components/Layout/index.ts
@@ -4,4 +4,3 @@ export { default as ActivityPaletteSidebar } from './ActivityPaletteSidebar';
 export { default as PropertiesSidebar } from './PropertiesSidebar';
 export { default as MainContent } from './MainContent';
 export { default as StatusBar } from './StatusBar';
-export { default as CodeModal } from './CodeModal';

--- a/packages/studio/src/components/SourceControl/ChangesView.tsx
+++ b/packages/studio/src/components/SourceControl/ChangesView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { lazy, useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/shallow';
@@ -7,7 +7,9 @@ import { useGitStore } from '../../stores/gitStore';
 import { Spinner } from '../Common/Loading';
 import ConfirmDialog from '../Common/ConfirmDialog';
 import FileStatusRow from './FileStatusRow';
-import DiffViewer from './DiffViewer';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const DiffViewer = lazy(() => import('./DiffViewer'));
 
 const ChangesView: React.FC = () => {
   const { t } = useTranslation('common');
@@ -252,11 +254,13 @@ const ChangesView: React.FC = () => {
       </div>
 
       {diffTarget && (
-        <DiffViewer
-          filePath={diffTarget.path}
-          staged={diffTarget.staged}
-          onClose={handleCloseDiff}
-        />
+        <LazyFeature>
+          <DiffViewer
+            filePath={diffTarget.path}
+            staged={diffTarget.staged}
+            onClose={handleCloseDiff}
+          />
+        </LazyFeature>
       )}
 
       <ConfirmDialog

--- a/packages/studio/src/hooks/useAiGeneration.ts
+++ b/packages/studio/src/hooks/useAiGeneration.ts
@@ -14,7 +14,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Edge } from '@xyflow/react';
 import { useEngine } from './useEngine';
-import { computeAutoLayout } from '../canvas/autoLayout';
+import { computeAutoLayout } from '../canvas/loadAutoLayout';
 import { buildDiagramFromAiResult } from '../utils/aiDiagramBuilder';
 import { normalizeActivitiesResult } from '../domain/activity';
 import type { ProcessNode } from '../stores/blockStore';

--- a/packages/studio/src/hooks/useFileOperations.ts
+++ b/packages/studio/src/hooks/useFileOperations.ts
@@ -36,7 +36,7 @@ import type { ProjectTemplate } from '../types/template';
 import { useMarketplaceStore } from '../stores/marketplaceStore';
 import { createLogger } from '../utils/logger';
 import { parseMermaidToDiagram } from '../utils/mermaidImporter';
-import { computeAutoLayout } from '../canvas/autoLayout';
+import { computeAutoLayout } from '../canvas/loadAutoLayout';
 
 const logger = createLogger('useFileOperations');
 


### PR DESCRIPTION
## Summary

- Lazy-load secondary Studio dialogs, Library Browser, diff viewer, Monaco-backed Python editor, and OnboardingTour at interaction boundaries.
- Load ELK only when auto-layout is requested.
- Add localized loading/error/retry states with a recoverable lazy-feature boundary.
- Add `check:bundle` to the renderer build and enforce entry/secondary JS/CSS budgets.

## Measurements

- Renderer entry: 4,065 KB → 1,794 KB.
- ELK is isolated in a 1,434 KB interaction chunk.
- Budget: entry ≤3,500 KB; largest secondary JS ≤1,500 KB; stylesheet ≤140 KB.

## Validation

- TypeScript: passed.
- Studio tests: 494/494 passed.
- Targeted lazy/auto-layout/i18n/Layout/diff/Monaco tests: 42/42 passed.
- Renderer build and bundle budget: passed.
- Full local NSIS packaging: timed out after renderer build at 184 seconds.
- Full repository lint remains blocked by pre-existing errors in FileMenu and PropertyPanel.

Closes #636