### PR TITLE
perf(studio): lazy-load secondary tools and enforce bundle budget

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -24,12 +24,15 @@ engine = StudioEngine()
 engine.executor.register_library("DesktopUI", DesktopUI())
 
 builder = engine.create_process("Notepad Automation")
-builder.add_task("Open and Type", [
-    ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
-    ("DesktopUI.Wait For Window",  {"title": "Notepad", "timeout": "10s"}),
-    ("DesktopUI.Input Text",       {"text": "Hello from RPAForge!"}),
-    ("DesktopUI.Close Window",     {}),
-])
+builder.add_task(
+    "Open and Type",
+    [
+        ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
+        ("DesktopUI.Wait For Window", {"title": "Notepad", "timeout": "10s"}),
+        ("DesktopUI.Input Text", {"text": "Hello from RPAForge!"}),
+        ("DesktopUI.Close Window", {}),
+    ],
+)
 
 result = engine.run(builder.build())
 print(f"Status: {result.status}")

--- a/packages/core/README.ru.md
+++ b/packages/core/README.ru.md
@@ -24,12 +24,15 @@ engine = StudioEngine()
 engine.executor.register_library("DesktopUI", DesktopUI())
 
 builder = engine.create_process("Notepad Automation")
-builder.add_task("Open and Type", [
-    ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
-    ("DesktopUI.Wait For Window",  {"title": "Notepad", "timeout": "10s"}),
-    ("DesktopUI.Input Text",       {"text": "Hello from RPAForge!"}),
-    ("DesktopUI.Close Window",     {}),
-])
+builder.add_task(
+    "Open and Type",
+    [
+        ("DesktopUI.Open Application", {"executable": "notepad.exe"}),
+        ("DesktopUI.Wait For Window", {"title": "Notepad", "timeout": "10s"}),
+        ("DesktopUI.Input Text", {"text": "Hello from RPAForge!"}),
+        ("DesktopUI.Close Window", {}),
+    ],
+)
 
 result = engine.run(builder.build())
 print(f"Status: {result.status}")

--- a/packages/studio/docs/bundle-budget.md
+++ b/packages/studio/docs/bundle-budget.md
@@ -1,0 +1,20 @@
+# Studio renderer bundle budget
+
+The renderer build is measured from the uncompressed files in `dist/assets`.
+`pnpm build` runs `check:bundle` immediately after Vite produces the renderer,
+so the Electron packaging job fails when a budget regresses.
+
+Baseline on 2026-07-25 before lazy-loading secondary tools:
+
+- Renderer entry: 4,065 KB
+- Largest JavaScript chunk: 663 KB
+- Largest stylesheet: 116 KB
+
+Current limits:
+
+- Renderer entry: 3,500 KB
+- Largest JavaScript chunk: 1,500 KB
+- Largest stylesheet: 140 KB
+
+The entry budget protects startup evaluation. The chunk and stylesheet budgets
+protect major interaction payloads without preventing intentional small chunks.

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -6,16 +6,18 @@
   "main": "dist-electron/electron/main.js",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && electron-builder",
+    "build": "pnpm build:renderer && electron-builder",
+    "build:renderer": "vite build && pnpm check:bundle",
     "build:bridge": "node scripts/build-bridge.mjs",
-    "build:dist": "node scripts/build-bridge.mjs && vite build && electron-builder",
+    "build:dist": "node scripts/build-bridge.mjs && pnpm build:renderer && electron-builder",
     "preview": "vite preview",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "electron:dev": "vite",
-    "electron:build": "vite build && electron-builder",
+    "electron:build": "pnpm build:renderer && electron-builder",
+    "check:bundle": "node scripts/check-bundle-size.mjs",
     "i18n:extract": "i18next-scanner --config i18next-scanner.config.cjs"
   },
   "keywords": [

--- a/packages/studio/public/locales/de/common.json
+++ b/packages/studio/public/locales/de/common.json
@@ -1180,6 +1180,11 @@
   "inlineLoading": {
     "loading": "Laden..."
   },
+  "lazyFeature": {
+    "loading": "Funktion wird geladen...",
+    "error": "Diese Funktion konnte nicht geladen werden.",
+    "retry": "Erneut versuchen"
+  },
   "fieldHelp": {
     "helpFor": "Hilfe für {{title}}",
     "format": "Format:",

--- a/packages/studio/public/locales/en/common.json
+++ b/packages/studio/public/locales/en/common.json
@@ -1214,6 +1214,11 @@
   "inlineLoading": {
     "loading": "Loading..."
   },
+  "lazyFeature": {
+    "loading": "Loading feature...",
+    "error": "This feature could not be loaded.",
+    "retry": "Try again"
+  },
   "fieldHelp": {
     "helpFor": "Help for {{title}}",
     "format": "Format:",

--- a/packages/studio/public/locales/es/common.json
+++ b/packages/studio/public/locales/es/common.json
@@ -1179,6 +1179,11 @@
   "inlineLoading": {
     "loading": "Cargando..."
   },
+  "lazyFeature": {
+    "loading": "Cargando función...",
+    "error": "No se pudo cargar esta función.",
+    "retry": "Intentar de nuevo"
+  },
   "fieldHelp": {
     "helpFor": "Ayuda para {{title}}",
     "format": "Formato:",

--- a/packages/studio/public/locales/ru/common.json
+++ b/packages/studio/public/locales/ru/common.json
@@ -1395,6 +1395,11 @@
   "inlineLoading": {
     "loading": "Загрузка..."
   },
+  "lazyFeature": {
+    "loading": "Загрузка функции...",
+    "error": "Не удалось загрузить эту функцию.",
+    "retry": "Повторить"
+  },
   "variablesPanel_noVariables": "Нет переменных",
   "variablesPanel_processVariables": "Переменные процесса",
   "variablesPanel_taskVariables": "Переменные задачи",

--- a/packages/studio/public/locales/zh/common.json
+++ b/packages/studio/public/locales/zh/common.json
@@ -1180,6 +1180,11 @@
   "inlineLoading": {
     "loading": "加载中..."
   },
+  "lazyFeature": {
+    "loading": "正在加载功能...",
+    "error": "无法加载此功能。",
+    "retry": "重试"
+  },
   "fieldHelp": {
     "helpFor": "{{title}} 的帮助",
     "format": "格式：",

--- a/packages/studio/scripts/check-bundle-size.mjs
+++ b/packages/studio/scripts/check-bundle-size.mjs
@@ -1,0 +1,71 @@
+import { readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DIST_DIR = fileURLToPath(new URL('../dist', import.meta.url));
+const BUDGETS = {
+  entryBytes: 3_500_000,
+  largestJavaScriptBytes: 1_500_000,
+  stylesheetBytes: 140_000,
+};
+
+async function collectFiles(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const filePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(filePath)));
+    } else {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+const files = await collectFiles(DIST_DIR);
+const assets = files.filter((filePath) => filePath.includes(`${path.sep}assets${path.sep}`));
+const javascript = assets.filter((filePath) => filePath.endsWith('.js'));
+const stylesheets = assets.filter((filePath) => filePath.endsWith('.css'));
+const entry = javascript.find((filePath) => path.basename(filePath).startsWith('index-'));
+
+if (!entry) {
+  throw new Error('Renderer bundle entry was not found in dist/assets.');
+}
+
+const sizes = await Promise.all(
+  assets.map(async (filePath) => ({
+    filePath,
+    bytes: (await stat(filePath)).size,
+  }))
+);
+const sizeByPath = new Map(sizes.map((asset) => [asset.filePath, asset.bytes]));
+const entryBytes = sizeByPath.get(entry);
+const secondaryJavaScript = javascript.filter((filePath) => filePath !== entry);
+const largestJavaScriptBytes = Math.max(...secondaryJavaScript.map((filePath) => sizeByPath.get(filePath)), 0);
+const stylesheetBytes = Math.max(...stylesheets.map((filePath) => sizeByPath.get(filePath)), 0);
+
+console.log(`Renderer entry: ${formatBytes(entryBytes)} / ${formatBytes(BUDGETS.entryBytes)}`);
+console.log(`Largest JavaScript chunk: ${formatBytes(largestJavaScriptBytes)} / ${formatBytes(BUDGETS.largestJavaScriptBytes)}`);
+console.log(`Largest stylesheet: ${formatBytes(stylesheetBytes)} / ${formatBytes(BUDGETS.stylesheetBytes)}`);
+
+const violations = [];
+if (entryBytes > BUDGETS.entryBytes) {
+  violations.push(`renderer entry exceeds ${formatBytes(BUDGETS.entryBytes)}`);
+}
+if (largestJavaScriptBytes > BUDGETS.largestJavaScriptBytes) {
+  violations.push(`a JavaScript chunk exceeds ${formatBytes(BUDGETS.largestJavaScriptBytes)}`);
+}
+if (stylesheetBytes > BUDGETS.stylesheetBytes) {
+  violations.push(`a stylesheet exceeds ${formatBytes(BUDGETS.stylesheetBytes)}`);
+}
+
+if (violations.length > 0) {
+  throw new Error(`Renderer bundle budget exceeded: ${violations.join('; ')}`);
+}

--- a/packages/studio/src/canvas/autoLayout.ts
+++ b/packages/studio/src/canvas/autoLayout.ts
@@ -13,7 +13,6 @@
  * so a swapped subtree order makes the wires visibly cross at the source.
  */
 
-import ELK from 'elkjs/lib/elk.bundled.js';
 import type { Node, Edge } from '@xyflow/react';
 import type { ProcessNodeData } from '../stores/blockStore';
 import {
@@ -24,8 +23,6 @@ import {
   type BlockPortConfig,
   type Port,
 } from '../types/blocks';
-
-const elk = new ELK();
 
 // Fallback size for nodes without a `measured` size yet (mirrors BaseBlock.tsx:
 // HEADER_HEIGHT 34 + MIN_CONTENT_HEIGHT 50 + PORT_LABELS_AREA 20, BASE_MIN_WIDTH 200).
@@ -140,6 +137,9 @@ export async function computeAutoLayout(
   if (nodes.length === 0) {
     return [];
   }
+
+  const { default: ELK } = await import('elkjs/lib/elk.bundled.js');
+  const elk = new ELK();
 
   // Collect pinned node positions so we can restore them after ELK runs.
   // Pinned nodes are still included in the ELK graph (with their current x/y

--- a/packages/studio/src/canvas/loadAutoLayout.ts
+++ b/packages/studio/src/canvas/loadAutoLayout.ts
@@ -1,0 +1,11 @@
+import type { Edge, Node } from '@xyflow/react';
+import type { ProcessNodeData } from '../stores/blockStore';
+import type { LayoutedPosition } from './autoLayout';
+
+export async function computeAutoLayout(
+  nodes: Node<ProcessNodeData>[],
+  edges: Edge[]
+): Promise<LayoutedPosition[]> {
+  const { computeAutoLayout: loadLayout } = await import('./autoLayout');
+  return loadLayout(nodes, edges);
+}

--- a/packages/studio/src/components/Common/FileMenu.tsx
+++ b/packages/studio/src/components/Common/FileMenu.tsx
@@ -54,11 +54,14 @@ import { MarketplaceDialog } from './MarketplaceDialog';
 import AiPromptLibrary from './AiPromptLibrary';
 import AiCompareDialog from './AiCompareDialog';
 import SettingsDialog from './SettingsDialog';
-import HelpDialog from './HelpDialog';
+import { lazy } from 'react';
+import { LazyFeature } from './LazyFeature';
 import SecurityAuditDialog from './SecurityAuditDialog';
 import { readFileAsText } from '../../utils/fileUtils';
 import type { ProcessNode } from '../../stores/blockStore';
 import type { AiProviderId } from '../../types/ai';
+
+const HelpDialog = lazy(() => import('./HelpDialog'));
 
 const getTemplateIcon = (iconName: string): React.ReactNode => {
   switch (iconName) {
@@ -1449,7 +1452,11 @@ const FileMenu: React.FC<FileMenuProps> = ({
       )}
 
       <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
-      <HelpDialog open={showShortcuts} onClose={() => setShowShortcuts(false)} />
+      {showShortcuts && (
+        <LazyFeature>
+          <HelpDialog open onClose={() => setShowShortcuts(false)} />
+        </LazyFeature>
+      )}
       <SecurityAuditDialog open={showSecurityAudit} onClose={() => setShowSecurityAudit(false)} />
     </>
   );

--- a/packages/studio/src/components/Common/LazyFeature.test.tsx
+++ b/packages/studio/src/components/Common/LazyFeature.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { LazyFeature } from './LazyFeature';
+
+let shouldThrow = true;
+
+function UnstableFeature() {
+  if (shouldThrow) {
+    throw new Error('feature chunk unavailable');
+  }
+
+  return <div>feature loaded</div>;
+}
+
+describe('LazyFeature', () => {
+  beforeEach(() => {
+    shouldThrow = true;
+  });
+
+  test('offers a retry after a feature error', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    render(
+      <LazyFeature>
+        <UnstableFeature />
+      </LazyFeature>
+    );
+
+    expect(screen.getByRole('alert').textContent).toContain('lazyFeature.error');
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: 'lazyFeature.retry' }));
+
+    expect(screen.getByText('feature loaded')).toBeTruthy();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/studio/src/components/Common/LazyFeature.tsx
+++ b/packages/studio/src/components/Common/LazyFeature.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+import { Suspense } from 'react';
+import { ErrorBoundary, type FallbackProps } from 'react-error-boundary';
+import { useTranslation } from 'react-i18next';
+
+interface LazyFeatureProps {
+  children: ReactNode;
+}
+
+function LazyFeatureFallback({ resetErrorBoundary }: FallbackProps) {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      className="flex items-center justify-center gap-3 p-4 text-sm text-ui-text-muted"
+      role="alert"
+      aria-live="assertive"
+    >
+      <span>{t('lazyFeature.error')}</span>
+      <button
+        type="button"
+        className="rounded bg-ui-primary px-3 py-1.5 text-ui-text-inverse hover:bg-ui-primary-hover"
+        onClick={resetErrorBoundary}
+      >
+        {t('lazyFeature.retry')}
+      </button>
+    </div>
+  );
+}
+
+export function LazyFeatureLoading() {
+  const { t } = useTranslation('common');
+
+  return (
+    <div
+      className="flex min-h-16 items-center justify-center p-4 text-sm text-ui-text-muted"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+    >
+      {t('lazyFeature.loading')}
+    </div>
+  );
+}
+
+export function LazyFeature({ children }: LazyFeatureProps) {
+  return (
+    <ErrorBoundary FallbackComponent={LazyFeatureFallback}>
+      <Suspense fallback={<LazyFeatureLoading />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/packages/studio/src/components/Designer/EditableTextField.tsx
+++ b/packages/studio/src/components/Designer/EditableTextField.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiMoreHorizontal } from 'react-icons/fi';
-import PythonCodeEditor from './PythonCodeEditor';
+import PythonCodeEditor from './LazyPythonCodeEditor';
 
 interface EditableTextFieldProps {
   value: string;

--- a/packages/studio/src/components/Designer/ExpressionEditor.tsx
+++ b/packages/studio/src/components/Designer/ExpressionEditor.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { FiPlus, FiMoreHorizontal, FiAlertCircle, FiCheckCircle, FiHelpCircle, FiX } from 'react-icons/fi';
 import type { VariableInfo } from './VariablePicker';
-import PythonCodeEditor from './PythonCodeEditor';
+import PythonCodeEditor from './LazyPythonCodeEditor';
 
 export interface ValidationResult {
   isValid: boolean;

--- a/packages/studio/src/components/Designer/LazyPythonCodeEditor.tsx
+++ b/packages/studio/src/components/Designer/LazyPythonCodeEditor.tsx
@@ -1,0 +1,17 @@
+import { lazy } from 'react';
+import type { ComponentProps } from 'react';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const PythonCodeEditor = lazy(() => import('./PythonCodeEditor'));
+
+type LazyPythonCodeEditorProps = ComponentProps<typeof PythonCodeEditor>;
+
+export default function LazyPythonCodeEditor(props: LazyPythonCodeEditorProps) {
+  if (!props.isOpen) return null;
+
+  return (
+    <LazyFeature>
+      <PythonCodeEditor {...props} />
+    </LazyFeature>
+  );
+}

--- a/packages/studio/src/components/Designer/ProcessCanvas.tsx
+++ b/packages/studio/src/components/Designer/ProcessCanvas.tsx
@@ -21,7 +21,7 @@ import {
   useViewport,
 } from '@xyflow/react';
 import { createActivityBlockData, type BlockData } from '../../types/blocks';
-import { computeAutoLayout } from '../../canvas/autoLayout';
+import { computeAutoLayout } from '../../canvas/loadAutoLayout';
 import { edgeTypes } from './Edges';
 import { ConnectionLine } from './Edges/ConnectionLine';
 import { blockNodeTypes } from './Blocks';

--- a/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
+++ b/packages/studio/src/components/Designer/PropertyPanel/PropertyPanel.tsx
@@ -6,7 +6,7 @@ import { getActivityDisplayLibrary, type Activity } from '../../../domain/activi
 import { getLibraryNamespace, getActivityKey } from '../../../utils/activityI18n';
 
 import VariableDialog, { type VariableDefinition } from '../VariableDialog';
-import PythonCodeEditor from '../PythonCodeEditor';
+import PythonCodeEditor from '../LazyPythonCodeEditor';
 import ParameterMappingDialog from '../ParameterMappingDialog';
 import DiagramSettingsDialog from '../DiagramSettingsDialog';
 import WorkflowStatisticsPanel from '../WorkflowStatisticsPanel';

--- a/packages/studio/src/components/Layout/Layout.tsx
+++ b/packages/studio/src/components/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { lazy, useState, useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
@@ -24,14 +24,16 @@ import ActivityPaletteSidebar from './ActivityPaletteSidebar';
 import PropertiesSidebar from './PropertiesSidebar';
 import MainContent from './MainContent';
 import StatusBar from './StatusBar';
-import CodeModal from './CodeModal';
 import ConfirmDialog from '../Common/ConfirmDialog';
 import { LoadingOverlay } from '../Common/Loading';
-import { MermaidPreview } from '../Common/MermaidPreview';
-import HelpDialog from '../Common/HelpDialog';
-import { WelcomeScreen } from '../Common/WelcomeScreen';
-import { OnboardingTour } from '../Common/OnboardingTour';
-import LibraryBrowser from '../LibraryBrowser/LibraryBrowser';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const CodeModal = lazy(() => import('./CodeModal'));
+const MermaidPreview = lazy(() => import('../Common/MermaidPreview'));
+const HelpDialog = lazy(() => import('../Common/HelpDialog'));
+const WelcomeScreen = lazy(() => import('../Common/WelcomeScreen').then(({ WelcomeScreen: component }) => ({ default: component })));
+const OnboardingTour = lazy(() => import('../Common/OnboardingTour'));
+const LibraryBrowser = lazy(() => import('../LibraryBrowser/LibraryBrowser'));
 
 const Layout: React.FC = () => {
   const { t } = useTranslation('common');
@@ -532,22 +534,30 @@ const Layout: React.FC = () => {
         onRestartBridge={() => { void window.rpaforge?.bridge.restart(); }}
       />
 
-      <CodeModal
-        isOpen={showCodeModal}
-        code={generatedCode}
-        files={generatedFiles}
-        fileCount={generatedFiles ? Object.keys(generatedFiles).length : 0}
-        onClose={handleCloseCodeModal}
-        onDownload={handleDownloadCode}
-      />
+      {showCodeModal && (
+        <LazyFeature>
+          <CodeModal
+            isOpen
+            code={generatedCode}
+            files={generatedFiles}
+            fileCount={generatedFiles ? Object.keys(generatedFiles).length : 0}
+            onClose={handleCloseCodeModal}
+            onDownload={handleDownloadCode}
+          />
+        </LazyFeature>
+      )}
 
-      <MermaidPreview
-        isOpen={showMermaidPreview}
-        onClose={() => setShowMermaidPreview(false)}
-        nodes={nodes}
-        edges={edges}
-        title={metadata?.name || t('layout.processDiagram')}
-      />
+      {showMermaidPreview && (
+        <LazyFeature>
+          <MermaidPreview
+            isOpen
+            onClose={() => setShowMermaidPreview(false)}
+            nodes={nodes}
+            edges={edges}
+            title={metadata?.name || t('layout.processDiagram')}
+          />
+        </LazyFeature>
+      )}
 
       <LoadingOverlay isVisible={loading.execute || loading.open} message={loadingMessage || t('layout.executing')} progress={executionProgress > 0 ? executionProgress : undefined} />
 
@@ -571,7 +581,11 @@ const Layout: React.FC = () => {
         onCancel={() => setStatefulDialog(null)}
       />
 
-      <HelpDialog open={showHelp} onClose={() => setShowHelp(false)} />
+      {showHelp && (
+        <LazyFeature>
+          <HelpDialog open onClose={() => setShowHelp(false)} />
+        </LazyFeature>
+      )}
 
       {showLibraryBrowser && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
@@ -586,26 +600,34 @@ const Layout: React.FC = () => {
               </button>
             </div>
             <div className="flex-1 overflow-y-auto">
-              <LibraryBrowser />
+              <LazyFeature>
+                <LibraryBrowser />
+              </LazyFeature>
             </div>
           </div>
         </div>
       )}
 
       {showWelcome && !project && (
-        <WelcomeScreen
-          onNewProcess={() => newProject('New Project')}
-          onOpenProcess={() => void handleOpenProject()}
-          onDismiss={() => setShowWelcome(false)}
-          onImportMermaid={handleShowMermaid}
-          onBrowseLibraries={() => setShowLibraryBrowser(true)}
-          onGettingStarted={() => {
-            setShowWelcome(false);
-          }}
-        />
+        <LazyFeature>
+          <WelcomeScreen
+            onNewProcess={() => newProject('New Project')}
+            onOpenProcess={() => void handleOpenProject()}
+            onDismiss={() => setShowWelcome(false)}
+            onImportMermaid={handleShowMermaid}
+            onBrowseLibraries={() => setShowLibraryBrowser(true)}
+            onGettingStarted={() => {
+              setShowWelcome(false);
+            }}
+          />
+        </LazyFeature>
       )}
 
-      <OnboardingTour />
+      {!isInitializing && (
+        <LazyFeature>
+          <OnboardingTour />
+        </LazyFeature>
+      )}
     </div>
   );
 };

--- a/packages/studio/src/components/Layout/index.ts
+++ b/packages/studio/src/components/Layout/index.ts
@@ -4,4 +4,3 @@ export { default as ActivityPaletteSidebar } from './ActivityPaletteSidebar';
 export { default as PropertiesSidebar } from './PropertiesSidebar';
 export { default as MainContent } from './MainContent';
 export { default as StatusBar } from './StatusBar';
-export { default as CodeModal } from './CodeModal';

--- a/packages/studio/src/components/SourceControl/ChangesView.tsx
+++ b/packages/studio/src/components/SourceControl/ChangesView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { lazy, useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import { useShallow } from 'zustand/shallow';
@@ -7,7 +7,9 @@ import { useGitStore } from '../../stores/gitStore';
 import { Spinner } from '../Common/Loading';
 import ConfirmDialog from '../Common/ConfirmDialog';
 import FileStatusRow from './FileStatusRow';
-import DiffViewer from './DiffViewer';
+import { LazyFeature } from '../Common/LazyFeature';
+
+const DiffViewer = lazy(() => import('./DiffViewer'));
 
 const ChangesView: React.FC = () => {
   const { t } = useTranslation('common');
@@ -252,11 +254,13 @@ const ChangesView: React.FC = () => {
       </div>
 
       {diffTarget && (
-        <DiffViewer
-          filePath={diffTarget.path}
-          staged={diffTarget.staged}
-          onClose={handleCloseDiff}
-        />
+        <LazyFeature>
+          <DiffViewer
+            filePath={diffTarget.path}
+            staged={diffTarget.staged}
+            onClose={handleCloseDiff}
+          />
+        </LazyFeature>
       )}
 
       <ConfirmDialog

--- a/packages/studio/src/hooks/useAiGeneration.ts
+++ b/packages/studio/src/hooks/useAiGeneration.ts
@@ -14,7 +14,7 @@
 import { useCallback, useRef, useState } from 'react';
 import type { Edge } from '@xyflow/react';
 import { useEngine } from './useEngine';
-import { computeAutoLayout } from '../canvas/autoLayout';
+import { computeAutoLayout } from '../canvas/loadAutoLayout';
 import { buildDiagramFromAiResult } from '../utils/aiDiagramBuilder';
 import { normalizeActivitiesResult } from '../domain/activity';
 import type { ProcessNode } from '../stores/blockStore';

--- a/packages/studio/src/hooks/useFileOperations.ts
+++ b/packages/studio/src/hooks/useFileOperations.ts
@@ -36,7 +36,7 @@ import type { ProjectTemplate } from '../types/template';
 import { useMarketplaceStore } from '../stores/marketplaceStore';
 import { createLogger } from '../utils/logger';
 import { parseMermaidToDiagram } from '../utils/mermaidImporter';
-import { computeAutoLayout } from '../canvas/autoLayout';
+import { computeAutoLayout } from '../canvas/loadAutoLayout';
 
 const logger = createLogger('useFileOperations');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion: '>=5.0.8'
   dompurify: '>=3.4.11'
+  fast-uri: '>=3.1.4'
   form-data: '>=4.0.6'
+  postcss: '>=8.5.18'
   undici: '>=7.28.0'
   vite: '>=8.0.16'
 
@@ -1589,9 +1592,6 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1614,15 +1614,9 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   browserslist@4.28.4:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
@@ -1753,9 +1747,6 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -2295,8 +2286,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@4.1.1:
+    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
@@ -2959,8 +2950,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3108,8 +3099,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -5167,7 +5158,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 4.1.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5263,8 +5254,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -5280,16 +5269,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@1.1.15:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.1.1:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5427,8 +5407,6 @@ snapshots:
       dot-prop: 5.3.0
 
   compare-version@0.1.2: {}
-
-  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -6043,7 +6021,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@4.1.1: {}
 
   fault@1.0.4:
     dependencies:
@@ -6667,19 +6645,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 5.0.8
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -6709,7 +6687,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -6867,9 +6845,9 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss@8.5.16:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7470,7 +7448,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.23
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,11 @@ packages:
   - 'packages/*'
 
 overrides:
+  brace-expansion: '>=5.0.8'
   dompurify: '>=3.4.11'
+  fast-uri: '>=3.1.4'
   form-data: '>=4.0.6'
+  postcss: '>=8.5.18'
   undici: '>=7.28.0'
   vite: '>=8.0.16'
 


### PR DESCRIPTION
## Summary

- Lazy-load secondary Studio dialogs, Library Browser, diff viewer, Monaco-backed Python editor, and OnboardingTour at interaction boundaries.
- Load ELK only when auto-layout is requested.
- Add localized loading/error/retry states with a recoverable lazy-feature boundary.
- Add `check:bundle` to the renderer build and enforce entry/secondary JS/CSS budgets.

## Measurements

- Renderer entry: 4,065 KB → 1,794 KB.
- ELK is isolated in a 1,434 KB interaction chunk.
- Budget: entry ≤3,500 KB; largest secondary JS ≤1,500 KB; stylesheet ≤140 KB.

## Validation

- TypeScript: passed.
- Studio tests: 494/494 passed.
- Targeted lazy/auto-layout/i18n/Layout/diff/Monaco tests: 42/42 passed.
- Renderer build and bundle budget: passed.
- Full local NSIS packaging: timed out after renderer build at 184 seconds.
- Full repository lint remains blocked by pre-existing errors in FileMenu and PropertyPanel.

Closes #636