### PR TITLE
fix(ci): resolve Node.js Dependency Audit failures by raising override floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   dompurify: '>=3.4.11'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   form-data: '>=4.0.6'
+  js-yaml: '>=4.3.1'
+  nanoid: '>=3.3.17'
   postcss: '>=8.5.18'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=8.0.16'
 
 importers:
@@ -1760,8 +1762,8 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.4:
@@ -2414,8 +2416,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
@@ -2774,8 +2776,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3058,9 +3060,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -3699,8 +3701,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.1.0:
@@ -4268,7 +4270,7 @@ snapshots:
       semver: 7.8.5
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 8.5.0
+      undici: 8.10.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5371,7 +5373,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5414,7 +5416,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.5
@@ -5474,7 +5476,7 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5509,7 +5511,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -5967,7 +5969,7 @@ snapshots:
       app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
     transitivePeerDependencies:
       - electron-builder-squirrel-windows
       - supports-color
@@ -6211,7 +6213,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fault@1.0.4:
     dependencies:
@@ -6581,7 +6583,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 
@@ -6602,7 +6604,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 8.5.0
+      undici: 8.10.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6808,19 +6810,19 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -6850,7 +6852,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@6.0.1: {}
 
   natural-compare@1.4.0: {}
 
@@ -6877,7 +6879,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.19
       tinyglobby: 0.2.17
-      undici: 8.5.0
+      undici: 8.10.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -7008,7 +7010,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 6.0.1
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7545,7 +7547,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@8.5.0: {}
+  undici@8.10.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,14 @@ packages:
   - 'packages/*'
 
 overrides:
-  brace-expansion: '>=5.0.8'
+  brace-expansion: '>=5.0.9'
   dompurify: '>=3.4.11'
-  fast-uri: '>=3.1.4'
+  fast-uri: '>=4.1.2'
   form-data: '>=4.0.6'
+  js-yaml: '>=4.3.1'
+  nanoid: '>=3.3.17'
   postcss: '>=8.5.18'
-  undici: '>=7.28.0'
+  undici: '>=8.9.0'
   vite: '>=8.0.16'
 
 allowBuilds:


### PR DESCRIPTION
## Summary

The **Node.js Dependencies Audit** gate has been failing on **every** pull request (#655–#661), including non-Node ones (#655 pnpm/action-setup, #661 setuptools). The failure did not depend on the PR diff — it was inherited from the shared `pnpm-lock.yaml` on every dependabot PR.

### Root cause

Overrides in `pnpm-workspace.yaml` were pinned to ranges **below** the patched versions in the GitHub advisories:

- `undici: '>=7.28.0'` → audit requires `>=8.9.0` (resolved 8.5.0)
- `fast-uri: '>=3.1.4'` → audit requires `>=4.1.2` (resolved 4.1.1)
- `brace-expansion: '>=5.0.8'` → audit requires `>=5.0.9` (resolved 5.0.8)
- `js-yaml` and `nanoid` → **no override at all**

`pnpm audit --json` + the JSON critical/high check therefore reported **5 high vulnerabilities** (all transitive, **dev-only** build/test-toolchain deps — they never ship in the production Electron bundle), failing the gate on every PR.

### Fix

Raised the override floors to the patched versions and added the missing ones:

| Module | Before | After (patched floor) |
|--------|--------|----------------------|
| brace-expansion | >=5.0.8 | **>=5.0.9** |
| fast-uri | >=3.1.4 | **>=4.1.2** |
| js-yaml | — | **>=4.3.1** |
| nanoid | — | **>=3.3.17** |
| undici | >=7.28.0 | **>=8.9.0** |

Regenerated `pnpm-lock.yaml` — the resolved versions are now brace-expansion 5.0.9, fast-uri 4.1.2, js-yaml 5.2.3, nanoid 6.0.1 (major bump to ESM), undici 8.10.0.

### Verification

- `pnpm audit` → **critical=0, high=0**
- `tsc --noEmit` clean across all 6 packages
- Full Studio `build:renderer` + `check:bundle` → EXIT 0
- Vitest 546/547 (the single `gitService pull()` timeout is a pre-existing concurrency flake, verified non-regression: runs green in isolation)

Once merged, the dependabot PRs #655–#661 will go green on the Security Audit gate.