### PR TITLE
fix(deps): close tar, DOMPurify and pymdown-extensions advisories

### DIFF
--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -102,8 +102,8 @@
     "vitest": "^4.1.10"
   },
   "overrides": {
-    "tar": ">=7.5.15",
-    "dompurify": ">=3.4.11",
+    "tar": ">=7.5.21",
+    "dompurify": ">=3.4.13",
     "@tootallnate/once": ">=3.0.1"
   },
   "build": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,13 @@ settings:
 
 overrides:
   brace-expansion: '>=5.0.9'
-  dompurify: '>=3.4.11'
+  dompurify: '>=3.4.13'
   fast-uri: '>=4.1.2'
   form-data: '>=4.0.6'
   js-yaml: '>=4.3.1'
   nanoid: '>=3.3.17'
   postcss: '>=8.5.18'
+  tar: '>=7.5.21'
   undici: '>=8.9.0'
   vite: '>=8.0.16'
 
@@ -109,8 +110,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       dompurify:
-        specifier: '>=3.4.11'
-        version: 3.4.11
+        specifier: '>=3.4.13'
+        version: 3.4.13
       elkjs:
         specifier: ^0.12.0
         version: 0.12.0
@@ -2226,8 +2227,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -3579,8 +3580,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.19:
-    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   temp-dir@3.0.0:
@@ -4997,7 +4998,7 @@ snapshots:
 
   '@types/dompurify@3.2.0':
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.13
 
   '@types/esrecurse@4.3.1': {}
 
@@ -5425,7 +5426,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.19
+      tar: 7.5.22
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       unzipper: 0.12.5
@@ -5978,7 +5979,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.11:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6784,7 +6785,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.21
-      dompurify: 3.4.11
+      dompurify: 3.4.13
       es-toolkit: 1.49.0
       katex: 0.16.47
       khroma: 2.1.0
@@ -6845,7 +6846,7 @@ snapshots:
 
   monaco-editor@0.56.0:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.13
       marked: 14.0.0
 
   mrmime@2.0.1: {}
@@ -6877,7 +6878,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.8.5
-      tar: 7.5.19
+      tar: 7.5.22
       tinyglobby: 0.2.17
       undici: 8.10.0
       which: 6.0.1
@@ -7420,7 +7421,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.19:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,13 @@ packages:
 
 overrides:
   brace-expansion: '>=5.0.9'
-  dompurify: '>=3.4.11'
+  dompurify: '>=3.4.13'
   fast-uri: '>=4.1.2'
   form-data: '>=4.0.6'
   js-yaml: '>=4.3.1'
   nanoid: '>=3.3.17'
   postcss: '>=8.5.18'
+  tar: '>=7.5.21'
   undici: '>=8.9.0'
   vite: '>=8.0.16'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.23",
     "mike>=1.1",
+    "pymdown-extensions>=11.0.1",
 ]
 desktop = [
     "pywinauto>=0.6.8",

--- a/uv.lock
+++ b/uv.lock
@@ -1727,15 +1727,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "11.0"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/67/f1e79672a5f91985577c7984c9709ca110e4fd37fe7fd167b60422e6ccc2/pymdown_extensions-11.0.tar.gz", hash = "sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589", size = 857049, upload-time = "2026-06-23T02:27:45.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b6/1ae53367e28b9cffa3be7574e13fbe4589694272fd47710fbdbafd3d63c6/pymdown_extensions-11.0-py3-none-any.whl", hash = "sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6", size = 269415, upload-time = "2026-06-23T02:27:43.826Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -2096,6 +2096,7 @@ docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "pymdown-extensions" },
 ]
 excel = [
     { name = "openpyxl" },
@@ -2124,6 +2125,7 @@ requires-dist = [
     { name = "playwright", marker = "extra == 'web'", specifier = ">=1.40" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=11.0.1" },
     { name = "pytesseract", marker = "extra == 'ocr'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },


### PR DESCRIPTION
## Summary

Closes 3 of the 10 open Dependabot alerts on main (the remaining ones are handled by the existing dependabot PRs #659, #660, #661).

### Changes

**Commit 1 — Raise tar and DOMPurify floor overrides to patched releases** (npm side)
- pnpm-workspace.yaml: add tar >=7.5.21, raise dompurify >=3.4.13
- packages/studio/package.json: keep package-level overrides in sync
- Regenerate pnpm-lock.yaml -> tar resolves to 7.5.22, dompurify to 3.4.13
- Closes: node-tar stack-overflow DoS (GHSA-r292-9mhp-454m), both DOMPurify XSS advisories (GHSA-55q2-fjhq-7xh7, GHSA-c2j3-45gr-mqc4)

**Commit 2 — Bump pymdown-extensions to patched release in docs extras** (python side)
- pyproject.toml: add pymdown-extensions>=11.0.1 to docs optional-dependencies
- Regenerate uv.lock -> pymdown-extensions resolves to 11.0.1
- Closes: exponential-backtracking ReDoS (GHSA-gm37-52c6-37mw)

### Verification
- pnpm audit -> 0 critical/high
- uv lock resolves clean; docs extras compile without conflict
- tsc --noEmit clean across all packages
