### PR TITLE
fix(deps): pin runtime setuptools above patched floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0",
     "pre-commit>=3.0",
+    "setuptools>=83.0.0",
     "invoke>=2.0",
 ]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -2090,6 +2090,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "setuptools" },
 ]
 docs = [
     { name = "mike" },
@@ -2133,6 +2134,7 @@ requires-dist = [
     { name = "pywinauto", marker = "extra == 'desktop'", specifier = ">=0.6.8" },
     { name = "rpaforge", extras = ["desktop", "web", "ocr", "excel", "database"], marker = "extra == 'all'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "setuptools", marker = "extra == 'dev'", specifier = ">=83.0.0" },
     { name = "sqlalchemy", marker = "extra == 'database'", specifier = ">=2.0" },
     { name = "uiautomation", marker = "extra == 'desktop'", specifier = ">=2.0" },
     { name = "xlwings", marker = "extra == 'excel'", specifier = ">=0.30" },
@@ -2415,11 +2417,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "81.0.0"
+version = "84.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the last open Dependabot alert (#84, medium): runtime setuptools pulled transitively by torch was pinned at 81.0.0 (< 83.0.0 patched floor).

## Changes

- pyproject.toml: pin `setuptools>=83.0.0` in the dev optional-dependencies
- Regenerate uv.lock so runtime setuptools resolves to 84.0.0 (pymdown-extensions stays at 11.0.1)

Closes: setuptools MANIFEST.in exclusion bypass (GHSA-h35f-9h28-mq5c)

### Verification
- uv lock resolves clean; setuptools 84.0.0, pymdown-extensions 11.0.1
