### PR TITLE
fix(credentials): harden vault encryption, encrypted export/import, env-var cleanup

### DIFF
--- a/packages/libraries/src/rpaforge_libraries/Credentials/library.py
+++ b/packages/libraries/src/rpaforge_libraries/Credentials/library.py
@@ -187,10 +187,24 @@ class Credentials:
             _vault_cache_time[vault_key] = time.monotonic()
 
     def _save_vault(self) -> None:
+        if not _CRYPTO_AVAILABLE:
+            raise RuntimeError(
+                _(
+                    "Cannot securely store credentials: 'cryptography' is not installed. "
+                    "Install 'cryptography' to enable vault encryption (CWE-256). "
+                    "Refusing to write the vault in plaintext."
+                )
+            )
         data = json.dumps(self._credentials, indent=2).encode()
         fernet = self._get_or_create_key()
-        if fernet:
-            data = fernet.encrypt(data)
+        if fernet is None:
+            raise RuntimeError(
+                _(
+                    "Cannot securely store credentials: unable to obtain a vault "
+                    "encryption key (CWE-256)."
+                )
+            )
+        data = fernet.encrypt(data)
         _atomic_write(self._vault_path, data)
         vault_key = str(self._vault_path)
         with _vault_cache_lock:
@@ -364,21 +378,47 @@ class Credentials:
             os.environ.pop(key, None)
         self._env_vars_set.clear()
 
+    def close(self) -> None:
+        """Explicitly release resources and clear credential environment vars.
+
+        Environment variables set by :meth:`set_environment_credential` are
+        visible to every child process spawned afterwards (CWE-522). Prefer
+        calling :meth:`close` (or the ``with`` statement) over relying on
+        garbage collection so secrets do not linger in ``os.environ``.
+        """
+        self.clear_environment_credentials()
+
     def __del__(self) -> None:
-        if hasattr(self, "_env_vars_set"):
-            self.clear_environment_credentials()
+        # Best-effort cleanup only — never raise from __del__ during shutdown.
+        try:
+            if hasattr(self, "_env_vars_set"):
+                self.clear_environment_credentials()
+        except Exception:
+            pass
 
     @activity(name="Export Credentials", category="Credentials")
     @tags("export", "credential")
     @output("Path to exported file")
     def export_credentials(
-        self, path: str | Path, names: list[str] | None = None
+        self,
+        path: str | Path,
+        names: list[str] | None = None,
+        encrypt: bool = True,
     ) -> str:
         """Export credentials to a file.
 
+        By default the export is encrypted with the same vault Fernet key so
+        no secret leaves storage in plaintext (CWE-312). Set ``encrypt=False``
+        only when an interoperable, human-readable dump is explicitly needed.
+
         :param path: Export file path.
         :param names: List of credential names to export (all if None).
+        :param encrypt: If True (default), the export is encrypted with the
+            vault key. A plaintext export is only produced when explicitly
+            requested with ``encrypt=False``.
         :returns: Path to exported file.
+        :raises RuntimeError: If ``encrypt=True`` but no vault key can be
+            obtained.
         """
         export_path = Path(path)
         to_export = {}
@@ -388,7 +428,19 @@ class Credentials:
                     to_export[name] = self._credentials[name]
         else:
             to_export = self._credentials.copy()
-        _atomic_write(export_path, json.dumps(to_export, indent=2).encode())
+        payload = json.dumps(to_export, indent=2).encode()
+        if encrypt:
+            fernet = self._get_or_create_key()
+            if fernet is None:
+                raise RuntimeError(
+                    _(
+                        "Cannot securely export credentials: vault encryption is "
+                        "unavailable. Refusing to write secrets in plaintext (CWE-312). "
+                        "Use encrypt=False only if a plaintext export is strictly required."
+                    )
+                )
+            payload = fernet.encrypt(payload)
+        _atomic_write(export_path, payload)
         logger.info(
             _("Exported {count} credentials to {path}", count=len(to_export), path=path)
         )
@@ -405,8 +457,28 @@ class Credentials:
         :returns: Number of imported credentials.
         """
         import_path = Path(path)
-        with open(import_path) as f:
-            imported = json.load(f)
+        if import_path.exists() and import_path.read_bytes().startswith(b"gAAAAA"):
+            fernet = self._get_or_create_key()
+            if fernet is None:
+                raise RuntimeError(
+                    _(
+                        "Cannot import an encrypted credentials file: vault encryption "
+                        "is unavailable on this system (CWE-312/256)."
+                    )
+                )
+            try:
+                data = fernet.decrypt(import_path.read_bytes())
+            except Exception as e:
+                raise ValueError(
+                    _(
+                        "Failed to decrypt the imported credentials file, key mismatch or corrupt data: {error}",
+                        error=e,
+                    )
+                ) from e
+            imported = json.loads(data)
+        else:
+            with open(import_path) as f:
+                imported = json.load(f)
         count = 0
         for name, cred in imported.items():
             if not isinstance(cred, dict):

--- a/packages/libraries/tests/test_credentials.py
+++ b/packages/libraries/tests/test_credentials.py
@@ -172,6 +172,114 @@ class TestCredentialsSecurity:
             cred1 = lib2.get_credential("cred1")
             assert cred1["username"] == "user1"
 
+    def test_export_encrypted_contains_no_plaintext(self):
+        """Encrypted export must not contain plaintext passwords (CWE-312)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            vault_path = Path(tmpdir) / "vault.json"
+            export_path = Path(tmpdir) / "export.json"
+
+            lib = Credentials(vault_path=vault_path)
+            lib.store_credential("cred1", "user1", "s3cret")
+            lib.store_credential("cred2", "user2", "p@ssw0rd")
+
+            lib.export_credentials(export_path)
+
+            raw = export_path.read_bytes()
+            assert raw.startswith(b"gAAAAA")
+            assert b"s3cret" not in raw
+            assert b"p@ssw0rd" not in raw
+
+    def test_export_plaintext_contains_secrets(self):
+        """Plaintext export (explicit encrypt=False) must contain secrets."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            vault_path = Path(tmpdir) / "vault.json"
+            export_path = Path(tmpdir) / "export.json"
+
+            lib = Credentials(vault_path=vault_path)
+            lib.store_credential("cred1", "user1", "s3cret")
+
+            lib.export_credentials(export_path, encrypt=False)
+
+            raw = export_path.read_bytes()
+            assert not raw.startswith(b"gAAAAA")
+            assert b"s3cret" in raw
+
+    def test_export_import_encrypted_roundtrip(self):
+        """Encrypted export -> import must restore passwords correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            vault1_path = Path(tmpdir) / "vault1.json"
+            export_path = Path(tmpdir) / "export.json"
+            vault2_path = Path(tmpdir) / "vault2.json"
+
+            lib1 = Credentials(vault_path=vault1_path)
+            lib1.store_credential("cred1", "user1", "s3cret")
+
+            lib1.export_credentials(export_path)
+
+            lib2 = Credentials(vault_path=vault2_path)
+            imported = lib2.import_credentials(export_path)
+            assert imported == 1
+
+            cred = lib2.get_credential("cred1")
+            assert cred["username"] == "user1"
+            assert cred["password"] == "s3cret"
+
+    def test_export_without_key_raises(self):
+        """Export with encrypt=True must refuse when no vault key is obtainable."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            vault_path = Path(tmpdir) / "vault.json"
+            lib = Credentials(vault_path=vault_path)
+
+            with patch.object(lib, "_get_or_create_key", return_value=None):
+                with pytest.raises(RuntimeError, match="plaintext"):
+                    lib.export_credentials(Path(tmpdir) / "export.json")
+
+    def test_save_vault_raises_when_crypto_unavailable(self):
+        """_save_vault must refuse plaintext writes when cryptography is missing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            lib = Credentials(vault_path=Path(tmpdir) / "vault.json")
+
+            with patch(
+                "rpaforge_libraries.Credentials.library._CRYPTO_AVAILABLE", False
+            ):
+                with pytest.raises(RuntimeError, match="plaintext"):
+                    lib.store_credential("test", "user", "pass")
+
+    def test_save_vault_raises_when_no_key(self):
+        """_save_vault must refuse to write without an encryption key (CWE-256)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            lib = Credentials(vault_path=Path(tmpdir) / "vault.json")
+
+            with patch.object(lib, "_get_or_create_key", return_value=None):
+                with pytest.raises(RuntimeError, match="encryption key"):
+                    lib.store_credential("test", "user", "pass")
+
+    def test_import_encrypted_without_key_raises(self):
+        """Importing an encrypted file without a key must raise, not silently clear."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            lib = Credentials(vault_path=Path(tmpdir) / "vault.json")
+
+            export_path = Path(tmpdir) / "export.json"
+            export_path.write_bytes(b"gAAAAA" + b"\x00" * 16)
+
+            with patch.object(lib, "_get_or_create_key", return_value=None):
+                with pytest.raises(RuntimeError):
+                    lib.import_credentials(export_path)
+
     def test_export_import_with_overwrite(self):
         """Test export and import with overwrite."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -266,6 +374,22 @@ class TestCredentialsSecurity:
 
             assert "TESTAPP_USERNAME" in os.environ
             assert "TESTAPP2_USERNAME" not in os.environ
+
+    def test_close_clears_env_vars(self):
+        """close() should explicitly clear environment credential vars (CWE-522)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            from rpaforge_libraries.Credentials import Credentials
+
+            lib = Credentials(vault_path=Path(tmpdir) / "vault.json")
+            lib.store_credential("test", "user1", "pass1")
+            lib.set_environment_credential("TESTAPP", "test")
+
+            assert os.environ.get("TESTAPP_USERNAME") == "user1"
+
+            lib.close()
+
+            assert "TESTAPP_USERNAME" not in os.environ
+            assert "TESTAPP_PASSWORD" not in os.environ
 
     def test_delete_cleans_env_vars(self):
         """Delete should not affect environment variables."""


### PR DESCRIPTION
## Summary

Security hardening for the Credentials RPA library, resolving three issues:

- **Closes #669** (CWE-312): \xport_credentials\ now encrypts the export with the vault Fernet key by default. A plaintext export requires an explicit \ncrypt=False\ opt-in.
- **Closes #670** (CWE-256): the vault no longer silently falls back to plaintext storage when \cryptography\ or a vault key is unavailable — it refuses to write instead.
- **Closes #671** (CWE-522): adds explicit \Credentials.close()\ and hardens \__del__\ to be best-effort/never-raising so env vars set by \set_environment_credential\ do not linger in \os.environ\.

## Changes

- \packages/libraries/src/rpaforge_libraries/Credentials/library.py\
  - \_save_vault\: raise \RuntimeError\ instead of silently writing plaintext (no crypto / no key).
  - \xport_credentials\: encrypt by default, \ncrypt=False\ opt-in.
  - \import_credentials\: transparently decrypt \gAAAAA\-prefixed exports; clear error on key mismatch/write-only files.
  - \close()\ added; \__del__\ made exception-safe.
- \packages/libraries/tests/test_credentials.py\: regression tests for all three issues (encrypted export contains no plaintext, encrypted round-trip, plaintext opt-in, refusal paths, env-var cleanup).

## Testing

- \pytest packages/libraries/tests/test_credentials.py packages/libraries/tests/test_credentials_atomic.py\ → 33 passed
- \uff check\ / \uff format --check\ → clean