### PR TITLE
fix(electron): validate LOG_WRITE IPC, wire spy channels, gate prod devtools, document CSP

### DIFF
--- a/packages/studio/electron/ipc-validation.test.ts
+++ b/packages/studio/electron/ipc-validation.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+
+import { describe, expect, test } from 'vitest';
+import Ajv from 'ajv';
+import { schemas } from '../src/types/ipc-schemas';
+
+const ajv = new Ajv({ allErrors: false, strict: false });
+
+describe('IPC schema validation (log:write + spy channels)', () => {
+  describe('log:write', () => {
+    const validate = ajv.compile(schemas['log:write']);
+
+    test('accepts a well-formed log entry', () => {
+      expect(
+        validate({
+          level: 'info',
+          scope: 'renderer',
+          message: 'Hello',
+          timestamp: '2026-08-16T00:00:00.000Z',
+        })
+      ).toBe(true);
+    });
+
+    test('accepts optional details field', () => {
+      expect(
+        validate({
+          level: 'error',
+          scope: 'bridge',
+          message: 'boom',
+          details: { code: 42 },
+          timestamp: '2026-08-16T00:00:00.000Z',
+        })
+      ).toBe(true);
+    });
+
+    test('rejects an invalid level', () => {
+      expect(
+        validate({
+          level: 'verbose',
+          scope: 's',
+          message: 'x',
+          timestamp: 't',
+        })
+      ).toBe(false);
+    });
+
+    test('rejects a missing required field', () => {
+      expect(
+        validate({
+          level: 'info',
+          scope: 's',
+          message: 'x',
+        })
+      ).toBe(false);
+    });
+
+    test('rejects additional unknown properties', () => {
+      expect(
+        validate({
+          level: 'info',
+          scope: 's',
+          message: 'x',
+          timestamp: 't',
+          evil: true,
+        })
+      ).toBe(false);
+    });
+
+    test('rejects very long messages', () => {
+      expect(
+        validate({
+          level: 'info',
+          scope: 's',
+          message: 'x'.repeat(20001),
+          timestamp: 't',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('spy_start / spy_stop', () => {
+    test('spy_start accepts a valid mode', () => {
+      const validate = ajv.compile(schemas['spy_start']);
+      expect(validate({ mode: 'web' })).toBe(true);
+      expect(validate({ mode: 'desktop' })).toBe(true);
+    });
+
+    test('spy_start rejects an invalid mode', () => {
+      const validate = ajv.compile(schemas['spy_start']);
+      expect(validate({ mode: 'mobile' })).toBe(false);
+      expect(validate({})).toBe(false);
+    });
+
+    test('spy_stop accepts an empty payload', () => {
+      const validate = ajv.compile(schemas['spy_stop']);
+      expect(validate({})).toBe(true);
+    });
+  });
+});

--- a/packages/studio/electron/main.ts
+++ b/packages/studio/electron/main.ts
@@ -110,6 +110,9 @@ let isSpyModeActive = false;
 let spyMode: 'web' | 'desktop' = 'desktop';
 
 const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
+// Explicit opt-in for opening DevTools in a production build (e.g. to debug a
+// startup/load failure). Leaks renderer internals, so it must not be automatic.
+const enableProdDevTools = process.env.RPAFORGE_DEVTOOLS === '1';
 const logger = createLogger('electron-main');
 const FS_DEBOUNCE_MS = 100;
 
@@ -314,6 +317,12 @@ function createWindow() {
         "form-action 'self'",
       ].join('; ')
     : [
+        // Production CSP: keep connect-src tight ('self'). All outbound network
+        // operations (AI providers incl. Ollama/Gemini/Anthropic, the library
+        // registry, PyPI, template marketplace) are performed by the MAIN process
+        // over IPC — they are NOT subject to this renderer CSP, so they keep
+        // working. If any network call is ever moved into the renderer, add the
+        // required endpoints here explicitly instead of loosening to '*'.
         "default-src 'self'",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline'",
@@ -373,8 +382,11 @@ function createWindow() {
     mainWindow.loadFile(indexPath).catch(err => {
       logger.error(`Failed to load index.html from: ${indexPath}`, err);
 
-      // Open dev tools to see the error
-      mainWindow!.webContents.openDevTools();
+      // Open dev tools to see the error — only with an explicit debug flag in
+      // production (leaks internals to end users otherwise).
+      if (enableProdDevTools) {
+        mainWindow!.webContents.openDevTools();
+      }
 
       // Show a blank page with error info
       const errorHtml = `
@@ -841,7 +853,7 @@ function setupIPCHandlers() {
     return pythonBridge?.sendRequest('captureDesktopElement', { x, y });
   });
 
-  ipcMain.handle('spy_start', (event, mode: 'web' | 'desktop') => {
+  ipcMain.handle(IPC_CHANNELS.SPY_START, (event, mode: 'web' | 'desktop') => {
     validateIPCPayload(event, 'spy_start', { mode });
     spyMode = mode;
     isSpyModeActive = true;
@@ -855,7 +867,7 @@ function setupIPCHandlers() {
     return { success: true };
   });
 
-  ipcMain.handle('spy_stop', (event) => {
+  ipcMain.handle(IPC_CHANNELS.SPY_STOP, (event) => {
     validateIPCPayload(event, 'spy_stop', {});
     isSpyModeActive = false;
     if (spyOverlayWindow && !spyOverlayWindow.isDestroyed()) {
@@ -1195,7 +1207,11 @@ function setupIPCHandlers() {
     }
   });
 
-  ipcMain.on(IPC_CHANNELS.LOG_WRITE, async (_, entry: LogEntry) => {
+  ipcMain.on(IPC_CHANNELS.LOG_WRITE, async (event, entry: LogEntry) => {
+    // LOG_WRITE is renderer→main; validate the payload like every other
+    // inbound channel so a compromised renderer cannot inject arbitrary
+    // log/file input (was the only unvalidated inbound channel).
+    validateIPCPayload(event, 'log:write', entry);
     logBuffer.push(entry);
     if (logBuffer.length > MAX_BUFFER_SIZE) {
       logBuffer.shift();

--- a/packages/studio/src/types/ipc-schemas.ts
+++ b/packages/studio/src/types/ipc-schemas.ts
@@ -1367,6 +1367,21 @@ const schemas: Record<string, SchemaDefinition> = {
     required: [],
     additionalProperties: false,
   },
+
+  'log:write': {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: 'log:write',
+    type: 'object',
+    properties: {
+      level: { type: 'string', enum: ['debug', 'info', 'warn', 'error'] },
+      scope: { type: 'string', maxLength: 255 },
+      message: { type: 'string', maxLength: 20000 },
+      details: {},
+      timestamp: { type: 'string' },
+    },
+    required: ['level', 'scope', 'message', 'timestamp'],
+    additionalProperties: false,
+  },
 };
 
 export { schemas };


### PR DESCRIPTION
## Summary

Security hardening for the Electron main process, resolving two issues:

- **Closes #682**: the LOG_WRITE IPC channel was the only unvalidated inbound channel — now validated against a new AJV "log:write" schema; spy_start/spy_stop moved onto the IPC_CHANNELS constants; openDevTools on production load failure now requires an explicit RPAFORGE_DEVTOOLS=1 opt-in.
- **Closes #685**: documented that the production CSP keeps connect-src='self' because all outbound network operations (AI providers including Ollama/Gemini/Anthropic, library registry, PyPI, templates) run in the MAIN process over IPC and are not subject to the renderer CSP; dev-only unsafe-eval/jsdelivr entries are already gated under isDev.

## Changes

- packages/studio/electron/main.ts
  - LOG_WRITE: added validateIPCPayload(event, "log:write", entry).
  - spy_start / spy_stop: register under IPC_CHANNELS.SPY_START / SPY_STOP.
  - Production load-failure openDevTools now behind enableProdDevTools (RPAFORGE_DEVTOOLS=1).
  - Production CSP: documentation comment explaining why connect-src stays 'self'.
- packages/studio/src/types/ipc-schemas.ts: added "log:write" schema (LogEntry shape/lengths).
- packages/studio/electron/ipc-validation.test.ts: new test suite for log:write + spy schemas.

## Testing

- pnpm vitest run electron/ipc-validation.test.ts -> 9 passed
- tsc renderer/electron: no new errors (19 pre-existing baseline unchanged)
- eslint: unchanged baseline (electron files outside lint project scope, same as main)
