### PR TITLE
fix(core): make psutil mandatory and bound subprocess pool lifecycle

### DIFF
--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -33,15 +33,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-subprocess = [
-    "psutil>=5.9",
-]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=4.0",
     "ruff>=0.15.0",
     "mypy>=1.0",
-    "psutil>=5.9",
 ]
 
 [project.urls]

--- a/packages/core/src/rpaforge/core/library_runner.py
+++ b/packages/core/src/rpaforge/core/library_runner.py
@@ -7,6 +7,7 @@ with AST-based import validation to prevent arbitrary code execution.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import logging
 import multiprocessing
@@ -18,19 +19,13 @@ import time
 from multiprocessing.pool import Pool as MultiprocessingPool
 from typing import Any
 
+import psutil
+
 from rpaforge.core.library_sandbox import (
     SandboxViolationError,
     validate_module_package,
 )
 from rpaforge.i18n import _ as _t
-
-try:
-    import psutil
-
-    _PSUTIL_AVAILABLE = True
-except ImportError:
-    _PSUTIL_AVAILABLE = False
-    psutil = None
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +88,7 @@ class LibraryRunner:
         self._cancel_generation = 0
         self._active_worker_pids: dict[int, Any] = {}
         self._active_lock = threading.Lock()
+        _register_runner(self)
 
     def _get_manager(self) -> Any:
         with self._pool_lock:
@@ -310,17 +306,9 @@ class LibraryRunner:
         except SubprocessCancelledError:
             raise
         except multiprocessing.TimeoutError as err:
-            if _PSUTIL_AVAILABLE and psutil is not None:
-                self._kill_worker_process(worker_pid.value)
-            else:
-                logger.warning(
-                    "psutil not available; recreating worker pool after timeout"
-                )
-                with self._pool_lock:
-                    if self._pool is pool:
-                        self._pool.terminate()
-                        self._pool.join()
-                        self._pool = None
+            # psutil is a hard dependency, so always kill only the stuck worker;
+            # the pool auto-repopulates it instead of being recreated.
+            self._kill_worker_process(worker_pid.value)
             raise TimeoutError(timeout_ms) from err
         finally:
             with self._pool_lock:
@@ -339,14 +327,12 @@ class LibraryRunner:
             if pool is None:
                 return
 
-            if _PSUTIL_AVAILABLE and psutil is not None:
-                with self._active_lock:
-                    active_pids = [
-                        worker_pid.value
-                        for worker_pid in self._active_worker_pids.values()
-                    ]
-                for worker_pid in active_pids:
-                    self._kill_worker_process(worker_pid)
+            with self._active_lock:
+                active_pids = [
+                    worker_pid.value for worker_pid in self._active_worker_pids.values()
+                ]
+            for worker_pid in active_pids:
+                self._kill_worker_process(worker_pid)
 
             pool.terminate()
             pool.join()
@@ -357,10 +343,9 @@ class LibraryRunner:
                 self._keepalive_timer = None
 
     def _kill_worker_process(self, worker_pid: int) -> None:
-        if not worker_pid or not _PSUTIL_AVAILABLE or psutil is None:
+        if not worker_pid:
             logger.warning(
-                "Unable to kill stuck worker (PID %s): psutil unavailable or invalid PID",
-                worker_pid,
+                "Unable to kill stuck worker (PID %s): invalid PID", worker_pid
             )
             return
 
@@ -383,23 +368,39 @@ class LibraryRunner:
             )
 
     def close(self) -> None:
-        """Close the runner and clean up resources."""
+        """Close the runner and clean up resources.
+
+        Idempotent and safe to call more than once (including from the
+        destructor and the atexit hook). After the first call the pool and
+        manager are detached, so later calls are no-ops.
+        """
         with self._pool_lock:
             self._closed = True
             if self._keepalive_timer is not None:
-                self._keepalive_timer.cancel()
-                self._keepalive_timer = None
+                try:
+                    self._keepalive_timer.cancel()
+                finally:
+                    self._keepalive_timer = None
             if self._pool is not None:
-                self._pool.terminate()
-                self._pool.join()
+                with contextlib.suppress(Exception):
+                    self._pool.terminate()
+                    self._pool.join()
                 self._pool = None
             if self._manager is not None:
-                self._manager.shutdown()
+                with contextlib.suppress(Exception):
+                    self._manager.shutdown()
                 self._manager = None
+            _unregister_runner(self)
 
     def __del__(self) -> None:
-        if hasattr(self, "_pool_lock"):
-            self.close()
+        # Destructors run at unpredictable times — including during interpreter
+        # shutdown when the module globals may already be torn down. Never allow
+        # cleanup here to raise (it would print a noisy traceback and crash out).
+        try:
+            if hasattr(self, "_pool_lock"):
+                self.close()
+        except Exception:
+            pass
 
     def __enter__(self) -> LibraryRunner:
         return self
@@ -411,6 +412,35 @@ class LibraryRunner:
         exc_tb: type[BaseException] | None,
     ) -> None:
         self.close()
+
+
+# Guaranteed cleanup: the (daemon) pool holds OS resources that would otherwise
+# linger until process exit even if a LibraryRunner is garbage-collected without
+# close()/context manager. Registering this hook makes shutdown bounded.
+_ACTIVE_RUNNERS: set[LibraryRunner] = set()
+_ACTIVE_RUNNERS_LOCK = threading.Lock()
+
+
+def _register_runner(runner: LibraryRunner) -> None:
+    with _ACTIVE_RUNNERS_LOCK:
+        _ACTIVE_RUNNERS.add(runner)
+
+
+def _unregister_runner(runner: LibraryRunner) -> None:
+    with _ACTIVE_RUNNERS_LOCK:
+        _ACTIVE_RUNNERS.discard(runner)
+
+
+def _shutdown_all_runners() -> None:
+    with _ACTIVE_RUNNERS_LOCK:
+        runners = list(_ACTIVE_RUNNERS)
+        _ACTIVE_RUNNERS.clear()
+    for runner in runners:
+        with contextlib.suppress(Exception):
+            runner.close()
+
+
+atexit.register(_shutdown_all_runners)
 
 
 def get_pool_stats() -> dict[str, Any]:

--- a/packages/core/src/rpaforge/core/subprocess_executor.py
+++ b/packages/core/src/rpaforge/core/subprocess_executor.py
@@ -8,6 +8,7 @@ for activity execution with timeout support.
 
 from __future__ import annotations
 
+import atexit
 import contextlib
 import logging
 import multiprocessing
@@ -17,15 +18,9 @@ import threading
 import time
 from typing import Any
 
+import psutil
+
 from rpaforge.i18n import _ as _t
-
-try:
-    import psutil
-
-    _PSUTIL_AVAILABLE = True
-except ImportError:
-    _PSUTIL_AVAILABLE = False
-    psutil = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +82,7 @@ class SubprocessExecutor:
         self._cancel_generation = 0
         self._active_worker_pids: dict[int, Any] = {}
         self._active_lock = threading.Lock()
+        _register_executor(self)
 
     def _get_manager(self) -> Any:
         with self._pool_lock:
@@ -288,19 +284,9 @@ class SubprocessExecutor:
         except SubprocessCancelledError:
             raise
         except multiprocessing.TimeoutError as err:
-            if _PSUTIL_AVAILABLE and psutil is not None:
-                # Kill only the specific stuck worker; pool auto-repopulates it.
-                self._kill_worker_process(worker_pid.value)
-            else:
-                # Without psutil we cannot target individual workers; recreate pool.
-                logger.warning(
-                    "psutil not available; recreating worker pool after timeout"
-                )
-                with self._pool_lock:
-                    if self._pool is pool:
-                        self._pool.terminate()
-                        self._pool.join()
-                        self._pool = None
+            # psutil is a hard dependency, so we can always kill only the
+            # specific stuck worker; the pool auto-repopulates it.
+            self._kill_worker_process(worker_pid.value)
             raise TimeoutError(timeout_ms) from err
         finally:
             with self._pool_lock:
@@ -319,14 +305,12 @@ class SubprocessExecutor:
             if pool is None:
                 return
 
-            if _PSUTIL_AVAILABLE and psutil is not None:
-                with self._active_lock:
-                    active_pids = [
-                        worker_pid.value
-                        for worker_pid in self._active_worker_pids.values()
-                    ]
-                for worker_pid in active_pids:
-                    self._kill_worker_process(worker_pid)
+            with self._active_lock:
+                active_pids = [
+                    worker_pid.value for worker_pid in self._active_worker_pids.values()
+                ]
+            for worker_pid in active_pids:
+                self._kill_worker_process(worker_pid)
 
             pool.terminate()
             pool.join()
@@ -338,9 +322,9 @@ class SubprocessExecutor:
 
     def _kill_worker_process(self, worker_pid: int) -> None:
         """Kill only the specific worker process that timed out."""
-        if not worker_pid or not _PSUTIL_AVAILABLE or psutil is None:
+        if not worker_pid:
             logger.warning(
-                "Unable to kill stuck worker (PID %s): psutil unavailable or invalid PID",
+                "Unable to kill stuck worker (PID %s): invalid PID",
                 worker_pid,
             )
             return
@@ -366,29 +350,74 @@ class SubprocessExecutor:
             )
 
     def close(self) -> None:
-        """Close the executor and clean up resources."""
+        """Close the executor and clean up resources.
+
+        Idempotent and safe to call more than once (including from the
+        destructor and the atexit hook). After the first call the pool and
+        manager are detached, so later calls are no-ops.
+        """
         with self._pool_lock:
             self._closed = True
             if self._keepalive_timer is not None:
-                self._keepalive_timer.cancel()
-                self._keepalive_timer = None
+                try:
+                    self._keepalive_timer.cancel()
+                finally:
+                    self._keepalive_timer = None
             if self._pool is not None:
-                self._pool.terminate()
-                self._pool.join()
+                with contextlib.suppress(Exception):
+                    self._pool.terminate()
+                    self._pool.join()
                 self._pool = None
             if self._manager is not None:
-                self._manager.shutdown()
+                with contextlib.suppress(Exception):
+                    self._manager.shutdown()
                 self._manager = None
+            _unregister_executor(self)
 
     def __del__(self) -> None:
-        if hasattr(self, "_pool_lock"):
-            self.close()
+        # Destructors run at unpredictable times — including during interpreter
+        # shutdown when the module globals may already be torn down. Never allow
+        # cleanup here to raise (it would print a noisy traceback and crash out).
+        try:
+            if hasattr(self, "_pool_lock"):
+                self.close()
+        except Exception:
+            pass
 
     def __enter__(self) -> SubprocessExecutor:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         self.close()
+
+
+# Guaranteed cleanup: the (daemon) pool holds OS resources that would otherwise
+# linger until process exit even if a SubprocessExecutor is garbage-collected
+# without close()/context manager. Registering this hook makes shutdown bounded.
+_LIVE_EXECUTORS: set[SubprocessExecutor] = set()
+_LIVE_EXECUTORS_LOCK = threading.Lock()
+
+
+def _register_executor(executor: SubprocessExecutor) -> None:
+    with _LIVE_EXECUTORS_LOCK:
+        _LIVE_EXECUTORS.add(executor)
+
+
+def _unregister_executor(executor: SubprocessExecutor) -> None:
+    with _LIVE_EXECUTORS_LOCK:
+        _LIVE_EXECUTORS.discard(executor)
+
+
+def _shutdown_all_executors() -> None:
+    with _LIVE_EXECUTORS_LOCK:
+        executors = list(_LIVE_EXECUTORS)
+        _LIVE_EXECUTORS.clear()
+    for executor in executors:
+        with contextlib.suppress(Exception):
+            executor.close()
+
+
+atexit.register(_shutdown_all_executors)
 
 
 def get_pool_stats() -> dict[str, Any]:

--- a/packages/core/tests/test_subprocess_executor.py
+++ b/packages/core/tests/test_subprocess_executor.py
@@ -115,29 +115,6 @@ class TestSubprocessExecutorTimeout:
             mod.SubprocessExecutor._execute_in_subprocess = original
             ex.close()
 
-    def test_pool_is_reset_after_timeout_without_psutil(self):
-        """Without psutil the pool is terminated and set to None after a timeout."""
-        import multiprocessing
-        import unittest.mock as mock
-
-        ex = SubprocessExecutor()
-
-        fake_async_result = mock.MagicMock()
-        fake_async_result.get.side_effect = multiprocessing.TimeoutError()
-
-        fake_pool = mock.MagicMock()
-        fake_pool.apply_async.return_value = fake_async_result
-
-        ex._pool = fake_pool
-
-        with mock.patch("rpaforge.core.subprocess_executor._PSUTIL_AVAILABLE", False):
-            with pytest.raises(TimeoutError):
-                ex.execute_with_timeout("fake.lib", "FakeClass", "act", timeout_ms=50)
-
-        assert ex._pool is None
-        fake_pool.terminate.assert_called_once()
-        fake_pool.join.assert_called_once()
-
     def test_pool_preserved_after_timeout_with_psutil(self):
         """With psutil the pool is kept alive after a timeout; workers are killed instead."""
         import multiprocessing
@@ -154,7 +131,6 @@ class TestSubprocessExecutorTimeout:
         ex._pool = fake_pool
 
         with (
-            mock.patch("rpaforge.core.subprocess_executor._PSUTIL_AVAILABLE", True),
             mock.patch("rpaforge.core.subprocess_executor.psutil", mock.MagicMock()),
             mock.patch.object(ex, "_kill_worker_process") as mock_kill,
         ):
@@ -311,5 +287,45 @@ class TestPersistentPool:
                 time.sleep(0.01)
             assert ex._pool is None
             assert ex._manager is None
+        finally:
+            ex.close()
+
+
+class TestSubprocessExecutorLifecycleRegistry:
+    """Executors self-register on construction and unregister on close, so the
+    atexit hook can release pool resources even if close() was never called."""
+
+    def test_constructed_executor_is_registered(self):
+        import rpaforge.core.subprocess_executor as mod
+
+        ex = SubprocessExecutor()
+        try:
+            with mod._LIVE_EXECUTORS_LOCK:
+                assert ex in mod._LIVE_EXECUTORS
+        finally:
+            ex.close()
+        with mod._LIVE_EXECUTORS_LOCK:
+            assert ex not in mod._LIVE_EXECUTORS
+
+    def test_close_unregisters_executor(self):
+        import rpaforge.core.subprocess_executor as mod
+
+        ex = SubprocessExecutor()
+        ex.close()
+        with mod._LIVE_EXECUTORS_LOCK:
+            assert ex not in mod._LIVE_EXECUTORS
+
+    def test_shutdown_all_executors_closes_registered(self):
+        import rpaforge.core.subprocess_executor as mod
+
+        ex = SubprocessExecutor()
+        try:
+            with mod._LIVE_EXECUTORS_LOCK:
+                mod._LIVE_EXECUTORS.discard(ex)
+                mod._LIVE_EXECUTORS.add(ex)
+            mod._shutdown_all_executors()
+            with mod._LIVE_EXECUTORS_LOCK:
+                assert ex not in mod._LIVE_EXECUTORS
+            assert ex._closed is True
         finally:
             ex.close()


### PR DESCRIPTION
## Summary

Stability fix for thread-timeout worker/resource leaks. Resolves #679.

**Root cause:** `ThreadingTimeoutHandler`/`LibraryRunner`/`SubprocessExecutor` relied on psutil being present only in some code paths. When psutil was unavailable, a timed-out activity left its worker process, pool, manager, and keepalive timer alive until process exit — a leak for long-running RPA processes. Additionally, `__del__` could raise during interpreter shutdown. And psutil was declared ambiguously: a hard base dependency *and* again under a useless `[subprocess]` extra.

**Changes:**
- Made `psutil` a genuine hard dependency in `packages/core/pyproject.toml` (removed the duplicated `[project.optional-dependencies].subprocess` group and the redundant dev-dependency entry).
- Removed all `try/except ImportError` + `_PSUTIL_AVAILABLE` guards in `subprocess_executor.py` and `library_runner.py`. Timeout/cancel paths now always target and kill only the stuck worker via psutil, preserving the pool (no silent pool recreation / leak).
- Bounded pool lifecycle: executors/runners self-register on construction and unregister on `close()`; a module-level `atexit` hook guarantees cleanup of pool/manager/keepalive-timer even when `close()` is never called.
- Made `close()` idempotent and `__del__` non-raising (safe during interpreter shutdown).
- Updated tests for the now-mandatory psutil path and added lifecycle-registry coverage.

**Verification:** full core suite `521 passed`; `ruff check` and `mypy` clean on changed files.

## Files
- packages/core/pyproject.toml
- packages/core/src/rpaforge/core/subprocess_executor.py
- packages/core/src/rpaforge/core/library_runner.py
- packages/core/tests/test_subprocess_executor.py
