### PR TITLE
fix(core): hard-fail on checksum mismatch and allow-list pip specs in library bridge

### DIFF
--- a/packages/core/src/rpaforge/bridge/handlers/libraries.py
+++ b/packages/core/src/rpaforge/bridge/handlers/libraries.py
@@ -6,9 +6,11 @@ import hashlib
 import importlib
 import importlib.metadata
 import logging
+import os
 import subprocess
 import sys
 import tempfile
+import urllib.error
 import urllib.parse
 import urllib.request
 from typing import TYPE_CHECKING, Any
@@ -27,6 +29,45 @@ logger = logging.getLogger("rpaforge.bridge.handlers.libraries")
 # from within the Studio UI because uninstalling them removes ALL built-in
 # # libraries at once (they share a single Python package).
 _CORE_PACKAGES = frozenset({"rpaforge-libraries", "rpaforge-core"})
+
+# Characters permitted in a pip package spec passed over IPC. Intentionally
+# strict: we allow only a single name (+ optional extras and version specifier).
+# Anything else (whitespace, `@`/VCS, `:` URLs, shell metacharacters, pip CLI
+# options) is rejected to stop a compromised renderer from injecting extra pip
+# arguments (e.g. "--index-url http://evil" or `; malicious`) — see #681.
+_ALLOWED_SPEC_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-+[]*,<>!=~"
+)
+
+
+def _validate_package_spec(spec: str) -> None:
+    """Reject package specs that could inject pip CLI args or shell commands.
+
+    Only a single, well-formed package spec is allowed: a PEP 508-style name
+    (with optional ``[extras]`` and version specifier like ``==1.0`` or
+    ``>=1.0,<2.0``). URLs, VCS refs, pip options, whitespace-separated extra
+    arguments, and shell metacharacters are all refused.
+
+    Args:
+        spec: The package spec string from IPC params.
+
+    Raises:
+        ValueError: If the spec is empty, starts with a pip option (`-`),
+            contains whitespace, or contains any character outside the allow-list.
+    """
+    if not spec or not spec.strip():
+        raise ValueError("pypiPackage must not be empty")
+    if spec.startswith("-"):
+        raise ValueError(
+            f"Invalid pip package spec {spec!r}: must not start with a '-'"
+        )
+    invalid = [c for c in spec if c not in _ALLOWED_SPEC_CHARS]
+    if invalid:
+        raise ValueError(
+            f"Invalid pip package spec {spec!r}: contains disallowed character(s) "
+            f"{''.join(dict.fromkeys(invalid))}. URLs, VCS references and pip "
+            "options are not permitted."
+        )
 
 
 def _compute_sha256(file_path: str) -> str:
@@ -94,36 +135,37 @@ def _verify_package_hash(pypi_package: str, expected_sha256: str | None) -> None
         return
 
     # Download the distribution file to a temp file
+    tmp_path: str | None = None
     try:
         with urllib.request.urlopen(dist_url, timeout=120) as response:
-            import os
-
             with tempfile.NamedTemporaryFile(delete=False, suffix=".whl") as tmp:
                 tmp.write(response.read())
                 tmp_path = tmp.name
 
-        try:
-            # Compute hash of downloaded file
-            actual_hash = _compute_sha256(tmp_path)
+        # Compute hash of downloaded file
+        actual_hash = _compute_sha256(tmp_path)
 
-            # Compare hashes (case-insensitive)
-            if actual_hash.lower() != expected_sha256.lower():
-                raise ValueError(
-                    f"Checksum mismatch for '{pypi_package}': "
-                    f"expected '{expected_sha256}', got '{actual_hash}'. "
-                    "The package may be corrupted or tampered with. Installation blocked."
-                )
+        # Compare hashes (case-insensitive). A mismatch is a hard failure that
+        # MUST propagate to the caller so the install is blocked — it indicates
+        # the artifact was corrupted or tampered with. Do NOT swallow it here.
+        if actual_hash.lower() != expected_sha256.lower():
+            raise ValueError(
+                f"Checksum mismatch for '{pypi_package}': "
+                f"expected '{expected_sha256}', got '{actual_hash}'. "
+                "The package may be corrupted or tampered with. Installation blocked."
+            )
 
-            logger.info(f"SHA-256 verification passed for {pypi_package}")
-        finally:
-            # Clean up temp file
-            if os.path.exists(tmp_path):
-                os.unlink(tmp_path)
-
-    except Exception as e:
+        logger.info(f"SHA-256 verification passed for {pypi_package}")
+    except (urllib.error.URLError, OSError, TimeoutError) as e:
+        # Transient/network failures: log a warning but do not hard-block the
+        # install (TLS still protects the transfer; this check is an integrity
+        # measure of last resort). A checksum mismatch (ValueError) is NOT
+        # caught here and flows up to the caller.
         logger.warning(f"Failed to verify package hash: {e}")
-        # Don't fail if verification fails - let pip handle it instead
-        # This provides defense-in-depth without blocking all installations
+    finally:
+        # Clean up temp file
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 def setup_libraries_handlers(bridge_handlers_class: type) -> None:
@@ -180,6 +222,7 @@ def setup_libraries_handlers(bridge_handlers_class: type) -> None:
         pypi_package = params.get("pypiPackage")
         if not pypi_package:
             raise ValueError("pypiPackage parameter required")
+        _validate_package_spec(pypi_package)
 
         # Verify SHA-256 hash if available
         expected_hash = params.get("sha256")
@@ -225,6 +268,7 @@ def setup_libraries_handlers(bridge_handlers_class: type) -> None:
         pypi_package = params.get("pypiPackage")
         if not pypi_package:
             raise ValueError("pypiPackage parameter required")
+        _validate_package_spec(pypi_package)
 
         # Verify SHA-256 hash if available
         expected_hash = params.get("sha256")
@@ -270,6 +314,7 @@ def setup_libraries_handlers(bridge_handlers_class: type) -> None:
         pypi_package = params.get("pypiPackage")
         if not pypi_package:
             raise ValueError("pypiPackage parameter required")
+        _validate_package_spec(pypi_package)
 
         # Prevent uninstalling core packages — doing so would remove ALL
         # built-in libraries at once (they share a single Python package).

--- a/packages/core/tests/test_bridge_libraries_handler.py
+++ b/packages/core/tests/test_bridge_libraries_handler.py
@@ -1,0 +1,121 @@
+"""Tests for bridge library-management security (hash verification + spec allow-list)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from rpaforge.bridge.handlers.libraries import (
+    _validate_package_spec,
+    _verify_package_hash,
+)
+
+
+class _FakeResponse:
+    """Minimal stand-in for urllib.request.urlopen's context-manager response."""
+
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _install_fake_pypi(monkeypatch, wheel_bytes: bytes, dist_url: str) -> None:
+    """Point the handler's network calls at a fake PyPI providing one wheel."""
+    pypi_json = {"info": {"urls": [{"url": dist_url, "filename": "test.whl"}]}}
+
+    def fake_urlopen(url, timeout=None):
+        if "pypi.org/pypi" in url:
+            return _FakeResponse(json.dumps(pypi_json).encode())
+        if url == dist_url:
+            return _FakeResponse(wheel_bytes)
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(
+        "rpaforge.bridge.handlers.libraries.urllib.request.urlopen", fake_urlopen
+    )
+
+
+class TestValidatePackageSpec:
+    """Security allow-list for pip package specs received over IPC (#681)."""
+
+    def test_accepts_simple_name(self):
+        _validate_package_spec("requests")
+
+    def test_accepts_normalized_name_with_underscores_dots(self):
+        _validate_package_spec("some_pkg-extra_thing")
+
+    def test_accepts_version_specifier(self):
+        _validate_package_spec("requests>=2.0,<3.0")
+        _validate_package_spec("flask==2.2.5")
+        _validate_package_spec("pandas>=1.5,!=1.6.0,<2.0")
+
+    def test_accepts_extras(self):
+        _validate_package_spec("rpaforge-libraries[ocr]")
+        _validate_package_spec("django[argon2,bcrypt]")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_package_spec("")
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_package_spec("   ")
+
+    def test_rejects_pip_option_injection(self):
+        with pytest.raises(ValueError, match="must not start with"):
+            _validate_package_spec("--index-url http://evil.example")
+        with pytest.raises(ValueError, match="must not start with"):
+            _validate_package_spec("--user numpy")
+
+    def test_rejects_whitespace_split_extra_args(self):
+        with pytest.raises(ValueError, match="disallowed character"):
+            _validate_package_spec("numpy --index-url http://evil.example")
+
+    def test_rejects_url_and_vcs(self):
+        with pytest.raises(ValueError, match="disallowed character"):
+            _validate_package_spec("git+https://github.com/evil/repo.git")
+        with pytest.raises(ValueError, match="disallowed character"):
+            _validate_package_spec("https://example.com/evil.whl")
+
+    def test_rejects_shell_metacharacters(self):
+        for spec in ("numpy; rm -rf /", "numpy& wget evil", "pkg|sh", "pkg`id`"):
+            with pytest.raises(ValueError, match="disallowed character"):
+                _validate_package_spec(spec)
+
+
+class TestVerifyPackageHashHardFail:
+    """A checksum mismatch must raise (block install), not be swallowed (#681)."""
+
+    def test_mismatched_file_hash_raises_value_error(self, monkeypatch):
+        """When the downloaded artifact does not match the expected hash, the
+        install must be blocked (ValueError propagates to the caller)."""
+        wheel_bytes = b"not-a-real-wheel-content"
+        dist_url = "https://files.example/test-1.0-py3-none-any.whl"
+        _install_fake_pypi(monkeypatch, wheel_bytes, dist_url)
+
+        # Expected hash (all zeros) intentionally differs from the artifact's.
+        with pytest.raises(ValueError, match="Checksum mismatch"):
+            _verify_package_hash("test-pkg", expected_sha256="0" * 64)
+
+    def test_matching_hash_passes(self, monkeypatch):
+        """A matching hash must not raise (verification passes)."""
+        wheel_bytes = b"real-wheel-content"
+        dist_url = "https://files.example/test-1.0-py3-none-any.whl"
+        expected = hashlib.sha256(wheel_bytes).hexdigest()
+        _install_fake_pypi(monkeypatch, wheel_bytes, dist_url)
+
+        # Must not raise.
+        _verify_package_hash("test-pkg", expected_sha256=expected)
+
+    def test_no_hash_provided_skips_verification(self):
+        """Backward compat: no expected hash => verification skipped silently."""
+        _verify_package_hash("some-pkg", expected_sha256=None)
+        _verify_package_hash("some-pkg", expected_sha256="   ")


### PR DESCRIPTION
Closes #681

## What
Security fixes for the library bridge handler (`packages/core/src/rpaforge/bridge/handlers/libraries.py`):

1. **Hard-fail on checksum mismatch** — `_verify_package_hash` previously swallowed a SHA-256 mismatch in a broad `except Exception` and let the install proceed ("Don't fail if verification fails"), making verification effectively advisory. Now the mismatch raises `ValueError`, which propagates to `install`/`update` and **blocks the install**. Only transient network/OS errors (`URLError`/`OSError`/`TimeoutError`) remain soft-fail.

2. **Allow-list pip specs** — new `_validate_package_spec` applied to `pip install`/`update`/`uninstall` IPC params. Rejects:
   - empty specs
   - leading `-` (pip options such as `--index-url`, `--user`)
   - whitespace (multi-argument injection)
   - URL / VCS references (`git+`, `https://`, `@`)
   - shell metacharacters (`; & | ` $ ...`)

   This prevents a compromised renderer from injecting extra pip CLI arguments or shell commands through IPC params.

## Testing
- Adds 12 unit tests in `test_bridge_libraries_handler.py` (spec allow-list + hard-fail-on-mismatch + backward-compat skip when no hash provided).
- Full core suite: **531 passed** (previously 521).
- `ruff` clean; `ruff format` applied; `mypy` clean on changed source.

## Note on issue item 3 (UI confirmation)
User-confirmation before third-party install is a UI-side change; the code-side hardening (items 1 & 2) is delivered here.