### PR TITLE
chore(libraries): fix OCR dependency declarations, drop dead easyocr

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -204,7 +204,7 @@ playwright install    # Laden Sie Browser-Binärdateien herunter
 | **Excel** | 8+ | XLSX-Tabellenkalkulationen lesen/schreiben | openpyxl |
 | **DataFrames** | 28+ | Tabellendatenoperationen — filtern, sortieren, verbinden, aggregieren | polars |
 | **Database** | 6+ | SQL-Abfragen über SQLAlchemy ORM | sqlalchemy |
-| **OCR** | 5+ | Texterkennung — Tesseract + EasyOCR | pytesseract, easyocr |
+| **OCR** | 5+ | Texterkennung — Tesseract + Barcodes | pytesseract, pyzbar, pyautogui |
 | **Credentials** | 4+ | Verschlüsselter OS-Anmeldedatenspeicher | cryptography, keyring |
 | **File** | 8+ | Datei- und Ordneroperationen | — |
 | **HTTP** | 5+ | REST API-Anfragen | requests |

--- a/README.es.md
+++ b/README.es.md
@@ -203,7 +203,7 @@ playwright install    # Descargar binarios del navegador
 | **Excel** | 8+ | Lectura/escritura de hojas de cálculo XLSX | openpyxl |
 | **DataFrames** | 28+ | Operaciones de datos tabulares — filtrar, ordenar, unir, agregar | polars |
 | **Database** | 6+ | Consultas SQL a través de SQLAlchemy ORM | sqlalchemy |
-| **OCR** | 5+ | Reconocimiento de texto — Tesseract + EasyOCR | pytesseract, easyocr |
+| **OCR** | 5+ | Reconocimiento de texto — Tesseract + códigos de barras | pytesseract, pyzbar, pyautogui |
 | **Credentials** | 4+ | Almacén de credenciales del SO cifrado | cryptography, keyring |
 | **File** | 8+ | Operaciones de archivos y carpetas | — |
 | **HTTP** | 5+ | Solicitudes de API REST | requests |

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ playwright install    # Downloads browser binaries
 | **Excel** | 8+ | Read/write XLSX spreadsheets | openpyxl |
 | **DataFrames** | 28+ | Tabular data operations — filter, sort, join, aggregate | polars |
 | **Database** | 6+ | SQL queries via SQLAlchemy ORM | sqlalchemy |
-| **OCR** | 5+ | Text recognition — Tesseract + EasyOCR | pytesseract, easyocr |
+| **OCR** | 5+ | Text recognition — Tesseract + barcodes | pytesseract, pyzbar, pyautogui |
 | **Credentials** | 4+ | Encrypted OS credential store | cryptography, keyring |
 | **File** | 8+ | File and folder operations | — |
 | **HTTP** | 5+ | REST API requests | requests |

--- a/README.ru.md
+++ b/README.ru.md
@@ -347,7 +347,7 @@ playwright install    # Загружает бинарные файлы брау�
 | **Excel** | 8+ | Чтение/запись XLSX-таблиц | openpyxl |
 | **DataFrames** | 28+ | Операции с табличными данными — фильтр, сортировка, объединение, агрегация | polars |
 | **Database** | 6+ | SQL-запросы через SQLAlchemy ORM | sqlalchemy |
-| **OCR** | 5+ | Распознавание текста — Tesseract + EasyOCR | pytesseract, easyocr |
+| **OCR** | 5+ | Распознавание текста — Tesseract + штрихкоды | pytesseract, pyzbar, pyautogui |
 | **Credentials** | 4+ | Зашифрованное хранилище учётных данных ОС | cryptography, keyring |
 | **File** | 8+ | Операции с файлами и папками | — |
 | **HTTP** | 5+ | REST API запросы | requests |

--- a/packages/libraries/README.md
+++ b/packages/libraries/README.md
@@ -35,7 +35,7 @@ pip install rpaforge-libraries
 # With optional dependencies
 pip install rpaforge-libraries[desktop]    # Desktop UI automation (pywinauto)
 pip install rpaforge-libraries[web]        # Web UI automation (playwright)
-pip install rpaforge-libraries[ocr]        # OCR support (tesseract, easyocr)
+pip install rpaforge-libraries[ocr]        # OCR support (pytesseract, pyzbar, pyautogui)
 pip install rpaforge-libraries[excel]      # Excel operations (openpyxl)
 pip install rpaforge-libraries[dataframes] # Tabular data (polars)
 pip install rpaforge-libraries[all]        # All dependencies

--- a/packages/libraries/README.ru.md
+++ b/packages/libraries/README.ru.md
@@ -35,7 +35,7 @@ pip install rpaforge-libraries
 # С опциональными зависимостями
 pip install rpaforge-libraries[desktop]    # Автоматизация Desktop UI (pywinauto)
 pip install rpaforge-libraries[web]        # Автоматизация Web UI (playwright)
-pip install rpaforge-libraries[ocr]        # Поддержка OCR (tesseract, easyocr)
+pip install rpaforge-libraries[ocr]        # Поддержка OCR (pytesseract, pyzbar, pyautogui)
 pip install rpaforge-libraries[excel]      # Операции с Excel (openpyxl)
 pip install rpaforge-libraries[dataframes] # Табличные данные (polars)
 pip install rpaforge-libraries[all]        # Все зависимости

--- a/packages/libraries/pyproject.toml
+++ b/packages/libraries/pyproject.toml
@@ -45,7 +45,8 @@ web = [
 ]
 ocr = [
     "pytesseract>=0.3.10",
-    "easyocr>=1.7",
+    "pyzbar>=0.1.9",
+    "pyautogui>=0.9.54",
     "pillow>=10.0",
 ]
 excel = [


### PR DESCRIPTION
## Summary

Fixes #678 — align the OCR package's declared `optional-dependencies` with what it actually imports at runtime.

`OCR.read_barcode` hard-imports **pyzbar** and `OCR.click_text` imports **pyautogui** at runtime, but neither was declared in the `ocr` extra — so `pip install rpaforge-libraries[ocr]` looked complete yet those activities failed with a catchable-but-unexpected ImportError. Meanwhile **easyocr** was declared but is never imported anywhere in the OCR package (verified by grep over `src/`): a dead dependency that dragged in the ~GB torch stack for no benefit.

## Changes

**`packages/libraries/pyproject.toml`**
- `ocr` extra now declares the real runtime deps: `pyzbar`, `pyautogui` (plus existing `pytesseract`, `pillow`).
- Removed the unused `easyocr>=1.7`.

**Documentation sync** (root + libraries README, en/ru/de/es)
- OCR rows now list `pytesseract, pyzbar, pyautogui` instead of the stale `pytesseract, easyocr`.
- `docs/developer-guide/building-installer*` and `ROADMAP.md` intentionally keep the historical note about the unbundled easyocr/torch stack — context, not a dependency claim.

**No library code changes needed** — the ImportError messages in `read_barcode` and `click_text` already tell users to install the right module/extra.

## Validation

- `pytest packages/libraries/tests/test_ocr.py` → **18 passed**.
- Full `packages/libraries/tests` → **729 passed, 2 skipped** (the single failure `test_connect_raises_import_error` is a pre-existing environment issue unrelated to this change).
- `pyproject.toml` parses; `ruff` clean.