### PR TITLE
fix(libraries): Excel write_range handles multi-letter columns like AA1

### DIFF
--- a/packages/libraries/src/rpaforge_libraries/Excel/library.py
+++ b/packages/libraries/src/rpaforge_libraries/Excel/library.py
@@ -178,15 +178,19 @@ class Excel:
         if not self._workbook:
             raise ValueError(_("No workbook open"))
         ws = self._workbook[sheet] if sheet else self._workbook.active
-        start_col = ord(start_cell[0].upper()) - ord("A")
-        start_row = (
-            int("".join(filter(str.isdigit, start_cell)))
-            if any(c.isdigit() for c in start_cell)
-            else 1
-        )
+        # Parse an A1-style address like "B3", "AA1" or "AB12" into 1-based
+        # (row, column). openpyxl's column_index_from_string handles multi-letter
+        # base-26 column labels (A..Z, AA..AZ, BA.. ZZ, AAA..), which the previous
+        # `ord(start_cell[0])` approach got wrong for anything past column Z.
+        from openpyxl.utils import column_index_from_string
+
+        letters = "".join(c for c in start_cell if c.isalpha()).upper()
+        digits = "".join(c for c in start_cell if c.isdigit())
+        start_col = column_index_from_string(letters if letters else "A")
+        start_row = int(digits) if digits else 1
         for i, row_data in enumerate(data):
             for j, value in enumerate(row_data):
-                cell = ws.cell(row=start_row + i, column=start_col + j + 1)
+                cell = ws.cell(row=start_row + i, column=start_col + j)
                 cell.value = value
         logger.info(
             _("wrote_range_starting_at_rows", start_cell=start_cell, count=len(data))

--- a/packages/libraries/tests/test_excel.py
+++ b/packages/libraries/tests/test_excel.py
@@ -66,6 +66,39 @@ class TestExcel:
         assert result == str(wb_path)
         lib.close_workbook()
 
+    @pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+    def test_write_range_multi_letter_column(self):
+        """write_range must honor multi-letter (base-26) columns like AA1, AB1."""
+
+        from rpaforge_libraries.Excel import Excel
+
+        lib = Excel()
+        lib.create_workbook()
+
+        # Write a 2x2 block starting at AA1 across and down.
+        lib.write_range("AA1", [["AA_first", "AB_second"], ["BA_third", "BB_fourth"]])
+        assert lib._workbook.active["AA1"].value == "AA_first"
+        assert lib._workbook.active["AB1"].value == "AB_second"
+        assert lib._workbook.active["AA2"].value == "BA_third"
+        assert lib._workbook.active["AB2"].value == "BB_fourth"
+
+        # A two-letter column assigned by the openpyxl cell API confirms index.
+        assert lib._workbook.active["AB1"].column == 28  # base-26: AB = 28
+        lib.close_workbook()
+
+    @pytest.mark.skipif(not openpyxl_available, reason="openpyxl not installed")
+    def test_write_range_multi_digit_row(self):
+        """write_range must parse row numbers with multiple digits (e.g. B12)."""
+
+        from rpaforge_libraries.Excel import Excel
+
+        lib = Excel()
+        lib.create_workbook()
+        lib.write_range("B12", [["target"]])
+        assert lib._workbook.active["B12"].value == "target"
+        assert lib._workbook.active["B13"].value is None  # nothing above/below
+        lib.close_workbook()
+
 
 class TestExcelKeywords:
     """Tests for Excel keyword signatures."""


### PR DESCRIPTION
## Summary

Fixes #694 — `Excel.write_range` now correctly handles multi-letter (base-26) column labels like `AA1`, `AB12`, etc.

## Root cause

`write_range` parsed the start cell by reading only its **first character**:

```python
start_col = ord(start_cell[0].upper()) - ord("A")
```

For `"AA1"` that yields column `0` (the `A` column) instead of column `27` — so writes landed in the wrong column for **any** label past `Z`.

## Changes

**`packages/libraries/src/rpaforge_libraries/Excel/library.py`**
- Replaced the naive single-char parser with openpyxl's `column_index_from_string`, which correctly parses multi-letter base-26 labels (`A..Z`, `AA..AZ`, `.. ZZ`, `AAA..`).
- Split letters and digits independently so both multi-letter columns **and** multi-digit rows (`B12`) are parsed robustly.
- `column_index_from_string` returns 1-based; the previous 0-based code added `+1`, so that `+1` is now removed to avoid an off-by-one.

## Tests

Added to `test_excel.py`:
- `test_write_range_multi_letter_column` — writes a 2×2 block starting at `AA1` and asserts values at `AA1`, `AB1`, `AA2`, `AB2` (including `AB1.column == 28`).
- `test_write_range_multi_digit_row` — writes at `B12` and reads it back.

## Validation

- `pytest packages/libraries/tests/test_excel.py` → **11 passed**.
- Full `packages/libraries/tests` → **731 passed, 2 skipped** (the single failure `test_connect_raises_import_error` is a pre-existing environment issue unrelated to this change).
- `ruff` clean.