### PR TITLE
refactor(core): introduce rpaforge.config module for paths and env settings (fixes #691)

### DIFF
--- a/packages/core/src/rpaforge/__init__.py
+++ b/packages/core/src/rpaforge/__init__.py
@@ -4,6 +4,7 @@ RPAForge Core - Open Source RPA Studio Engine.
 Native Python execution engine without Robot Framework dependencies.
 """
 
+from rpaforge import config
 from rpaforge.bridge import BridgeServer
 from rpaforge.codegen import CodeGenerator
 from rpaforge.core.runner import (
@@ -14,6 +15,7 @@ from rpaforge.core.runner import (
 )
 
 __all__ = [
+    "config",
     "StudioEngine",
     "ProcessRunner",
     "Breakpoint",

--- a/packages/core/src/rpaforge/bridge/server.py
+++ b/packages/core/src/rpaforge/bridge/server.py
@@ -30,6 +30,7 @@ if sys.platform == "win32":
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(encoding="utf-8", newline="")
 
+from rpaforge import config
 from rpaforge.bridge.handlers import BridgeHandlers
 from rpaforge.bridge.protocol import (
     JSONRPCError,
@@ -339,7 +340,7 @@ class BridgeServer:
         rpaforge_logger = logging.getLogger("rpaforge")
         rpaforge_logger.addHandler(self._log_handler)
 
-        log_level = os.environ.get("RPAFORGE_LOG_LEVEL", "INFO").upper()
+        log_level = config.get_log_level()
         rpaforge_logger.setLevel(getattr(logging, log_level, logging.INFO))
 
     def _teardown_logging(self) -> None:

--- a/packages/core/src/rpaforge/config.py
+++ b/packages/core/src/rpaforge/config.py
@@ -1,0 +1,145 @@
+"""Centralized configuration for RPAForge core.
+
+Single source of truth for environment-driven settings and platform-aware
+data paths that were previously scattered across modules:
+
+- env vars: ``RPAFORGE_LOG_LEVEL``, ``RPAFORGE_MAX_WORKERS_LIMIT``,
+  ``LANG`` (see ``ENV_*`` constants below).
+- hardcoded paths: the per-user runs directory (``~/.rpaforge/runs``) and the
+  per-user app-data directory used for checkpoints.
+
+All path getters resolve **lazily** (at call time) rather than at import time —
+callers rely on this for testability (e.g. ``Path.home()`` is monkeypatched in
+the test suite) and so that the module can be imported before any user-specific
+path is known.
+
+Supported environment variables
+-------------------------------
+- ``RPAFORGE_LOG_LEVEL``: root log level for the ``rpaforge`` logger
+  (default ``"INFO"``).
+- ``RPAFORGE_MAX_WORKERS_LIMIT``: upper cap on the subprocess worker pool
+  (default ``multiprocessing.cpu_count() * 4``).
+- ``RPAFORGE_DATA_DIR``: override the platform app-data directory. When unset,
+  the platform default is used.
+- ``LANG``: locale hint used by :mod:`rpaforge.i18n` (default ``"en"``).
+
+Paths are read once per call so an explicit ``RPAFORGE_DATA_DIR`` or a change
+in the environment is picked up. Importing this module performs no I/O.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import sys
+from pathlib import Path
+
+__all__ = [
+    "ENV_LOG_LEVEL",
+    "ENV_DATA_DIR",
+    "ENV_MAX_WORKERS_LIMIT",
+    "DEFAULT_LOG_LEVEL",
+    "DEFAULT_LANG",
+    "get_log_level",
+    "get_lang",
+    "get_max_workers_limit",
+    "get_app_data_dir",
+    "get_runs_dir",
+    "get_default_checkpoint_dir",
+]
+
+#: Environment variable that controls the root ``rpaforge`` logger level.
+ENV_LOG_LEVEL = "RPAFORGE_LOG_LEVEL"
+#: Environment variable that caps the subprocess worker pool size.
+ENV_MAX_WORKERS_LIMIT = "RPAFORGE_MAX_WORKERS_LIMIT"
+#: Environment variable that overrides the platform app-data directory.
+ENV_DATA_DIR = "RPAFORGE_DATA_DIR"
+
+#: Fallback log level when ``RPAFORGE_LOG_LEVEL`` is unset or unrecognized.
+DEFAULT_LOG_LEVEL = "INFO"
+#: Fallback language when ``LANG`` is unset.
+DEFAULT_LANG = "en"
+
+
+def get_log_level() -> str:
+    """Return the root log level name (e.g. ``"INFO"``).
+
+    Reads ``RPAFORGE_LOG_LEVEL``; falls back to :data:`DEFAULT_LOG_LEVEL`
+    when unset. The value is uppercased and unvalidated here — the caller is
+    responsible for mapping it to a :mod:`logging` level.
+    """
+    return os.environ.get(ENV_LOG_LEVEL, DEFAULT_LOG_LEVEL).upper()
+
+
+def get_lang() -> str:
+    """Return the raw locale hint from ``LANG`` (e.g. ``"en"``).
+
+    Mirrors the historical reading: values like ``"en_US.UTF-8"`` are trimmed
+    to the language code. Callers that restrict to a supported set (see
+    :mod:`rpaforge.i18n`) apply their own filtering afterwards.
+    """
+    return os.environ.get("LANG", DEFAULT_LANG).split("_")[0]
+
+
+def get_max_workers_limit() -> int:
+    """Return the maximum allowed worker-pool size.
+
+    Reads ``RPAFORGE_MAX_WORKERS_LIMIT``; defaults to
+    ``multiprocessing.cpu_count() * 4``. The value is coerced to ``int`` and
+    defaults to 0 when parsing fails (callers clamp against their own minimum).
+    """
+    raw = os.environ.get(ENV_MAX_WORKERS_LIMIT, str(multiprocessing.cpu_count() * 4))
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def get_app_data_dir() -> Path:
+    """Return the per-user application-data directory (platform-aware).
+
+    Resolution order:
+    1. ``RPAFORGE_DATA_DIR`` (explicit override).
+    2. Windows: ``%LOCALAPPDATA%\\RPAForge`` (falling back to
+       ``~/AppData/Local/RPAForge`` when ``LOCALAPPDATA`` is unset).
+    3. macOS: ``~/Library/Application Support/RPAForge``.
+    4. Linux/other: ``$XDG_CONFIG_HOME/rpaforge`` (falling back to
+       ``~/.config/rpaforge``).
+
+    The path is returned but **not** created; callers that need it on disk
+    should ``mkdir(parents=True, exist_ok=True)`` themselves.
+    """
+    override = os.environ.get(ENV_DATA_DIR)
+    if override:
+        return Path(override)
+
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        return (Path(base) if base else Path.home() / "AppData" / "Local") / "RPAForge"
+
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "RPAForge"
+
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "rpaforge"
+    return Path.home() / ".config" / "rpaforge"
+
+
+def get_runs_dir() -> Path:
+    """Return the directory used to persist run audits.
+
+    Resolves lazily to ``~/.rpaforge/runs`` so that a changed ``$HOME`` (or a
+    monkeypatched :meth:`pathlib.Path.home`) is honored per call.
+    """
+    return Path.home() / ".rpaforge" / "runs"
+
+
+def get_default_checkpoint_dir() -> Path:
+    """Return the default checkpoint directory.
+
+    Uses the platform app-data directory (``<app-data>/checkpoints``). To
+    override for the whole machine use ``RPAFORGE_DATA_DIR``; to override per
+    ``CheckpointManager`` instance pass ``checkpoint_dir`` explicitly.
+    """
+    return get_app_data_dir() / "checkpoints"

--- a/packages/core/src/rpaforge/core/_worker_pool.py
+++ b/packages/core/src/rpaforge/core/_worker_pool.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import psutil
 
+from rpaforge import config
 from rpaforge.i18n import _ as _t
 
 logger = logging.getLogger(__name__)
@@ -37,9 +38,7 @@ class SubprocessCancelledError(Exception):
 
 DEFAULT_POOL_KEEPALIVE_SECONDS = 60
 MIN_WORKERS = 1
-MAX_WORKERS_LIMIT = int(
-    os.environ.get("RPAFORGE_MAX_WORKERS_LIMIT", str(multiprocessing.cpu_count() * 4))
-)
+MAX_WORKERS_LIMIT = config.get_max_workers_limit()
 
 
 def get_pool_stats() -> dict[str, Any]:

--- a/packages/core/src/rpaforge/core/checkpoint.py
+++ b/packages/core/src/rpaforge/core/checkpoint.py
@@ -17,6 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from rpaforge import config
 from rpaforge.core.models import Breakpoint, CallFrame
 
 logger = logging.getLogger("rpaforge")
@@ -97,10 +98,20 @@ class CheckpointManager:
         checkpoint_dir: str | Path | None = None,
         frequency: int = DEFAULT_CHECKPOINT_FREQUENCY,
         keep_last: int = DEFAULT_KEEP_CHECKPOINTS,
+        project_id: str | None = None,
     ) -> None:
-        self._checkpoint_dir = (
-            Path(checkpoint_dir) if checkpoint_dir else Path(DEFAULT_CHECKPOINT_DIR)
-        )
+        if checkpoint_dir is not None:
+            self._checkpoint_dir = Path(checkpoint_dir)
+        else:
+            base_dir = config.get_default_checkpoint_dir()
+            if project_id:
+                safe_id = "".join(
+                    c if c.isalnum() or c in ("-", "_") else "_" for c in project_id
+                )
+                self._checkpoint_dir = base_dir / safe_id
+            else:
+                self._checkpoint_dir = base_dir
+
         self._frequency = max(1, frequency)
         self._keep_last = max(1, keep_last)
         self._lock = threading.Lock()

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -13,6 +13,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from rpaforge import config
 from rpaforge.core.audit import RunRecord, StepRecord
 from rpaforge.core.execution import (
     ActivityCall,
@@ -515,8 +516,7 @@ class ProcessRunner:
 
         # Save to disk
         try:
-            # Use home directory .rpaforge for now; can be enhanced to use project root
-            runs_dir = Path.home() / ".rpaforge" / "runs"
+            runs_dir = config.get_runs_dir()
             self._last_audit_path = self._current_run.save(runs_dir)
             self._cleanup_old_runs(runs_dir, keep=50)
         except Exception as e:

--- a/packages/core/src/rpaforge/i18n.py
+++ b/packages/core/src/rpaforge/i18n.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import Any
 
+from rpaforge import config
+
 __all__ = ["_"]
 
 logger = logging.getLogger("rpaforge.i18n")
@@ -62,7 +64,7 @@ def _(message: str, **kwargs: str | int | float) -> str:
         Translated and interpolated message, or the key itself if translation not found.
     """
     # Determine language
-    lang = os.getenv("LANG", "en").split("_")[0]
+    lang = config.get_lang()
     if lang not in ("en", "ru", "de", "es"):
         lang = "en"
 

--- a/packages/core/tests/test_checkpoint.py
+++ b/packages/core/tests/test_checkpoint.py
@@ -87,6 +87,18 @@ class TestCheckpointManager:
             assert cm.frequency == DEFAULT_CHECKPOINT_FREQUENCY
             assert cm.checkpoint_dir == Path(tmpdir)
 
+    def test_init_default_config_dir(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.setenv("RPAFORGE_DATA_DIR", tmpdir)
+            cm = CheckpointManager()
+            assert cm.checkpoint_dir == Path(tmpdir) / "checkpoints"
+
+    def test_init_project_id_namespacing(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.setenv("RPAFORGE_DATA_DIR", tmpdir)
+            cm = CheckpointManager(project_id="my-project/v1")
+            assert cm.checkpoint_dir == Path(tmpdir) / "checkpoints" / "my-project_v1"
+
     def test_init_custom_values(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cm = CheckpointManager(checkpoint_dir=tmpdir, frequency=5, keep_last=2)

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -70,10 +70,8 @@ class TestConfigAppDataDir:
     def test_windows_app_data_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("RPAFORGE_DATA_DIR", raising=False)
         monkeypatch.setattr(sys, "platform", "win32")
-        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Test\AppData\Local")
-        assert config.get_app_data_dir() == Path(
-            r"C:\Users\Test\AppData\Local\RPAForge"
-        )
+        monkeypatch.setenv("LOCALAPPDATA", "C:/Users/Test/AppData/Local")
+        assert config.get_app_data_dir() == Path("C:/Users/Test/AppData/Local/RPAForge")
 
     def test_mac_app_data_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("RPAFORGE_DATA_DIR", raising=False)

--- a/packages/core/tests/test_config.py
+++ b/packages/core/tests/test_config.py
@@ -1,0 +1,104 @@
+"""Tests for rpaforge.config module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from rpaforge import config
+
+
+class TestConfigLogLevel:
+    """Tests for log level configuration."""
+
+    def test_default_log_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RPAFORGE_LOG_LEVEL", raising=False)
+        assert config.get_log_level() == "INFO"
+
+    def test_custom_log_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RPAFORGE_LOG_LEVEL", "debug")
+        assert config.get_log_level() == "DEBUG"
+
+
+class TestConfigLang:
+    """Tests for language locale configuration."""
+
+    def test_default_lang(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("LANG", raising=False)
+        assert config.get_lang() == "en"
+
+    def test_custom_lang_simple(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANG", "de")
+        assert config.get_lang() == "de"
+
+    def test_custom_lang_locale_code(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("LANG", "ru_RU.UTF-8")
+        assert config.get_lang() == "ru"
+
+
+class TestConfigMaxWorkersLimit:
+    """Tests for worker pool limit configuration."""
+
+    def test_default_max_workers_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RPAFORGE_MAX_WORKERS_LIMIT", raising=False)
+        limit = config.get_max_workers_limit()
+        assert isinstance(limit, int)
+        assert limit > 0
+
+    def test_custom_max_workers_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RPAFORGE_MAX_WORKERS_LIMIT", "16")
+        assert config.get_max_workers_limit() == 16
+
+    def test_invalid_max_workers_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("RPAFORGE_MAX_WORKERS_LIMIT", "invalid_number")
+        assert config.get_max_workers_limit() == 0
+
+
+class TestConfigAppDataDir:
+    """Tests for app data directory resolution."""
+
+    def test_explicit_data_dir_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        custom_dir = tmp_path / "custom_data"
+        monkeypatch.setenv("RPAFORGE_DATA_DIR", str(custom_dir))
+        assert config.get_app_data_dir() == custom_dir
+
+    def test_windows_app_data_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RPAFORGE_DATA_DIR", raising=False)
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Test\AppData\Local")
+        assert config.get_app_data_dir() == Path(
+            r"C:\Users\Test\AppData\Local\RPAForge"
+        )
+
+    def test_mac_app_data_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RPAFORGE_DATA_DIR", raising=False)
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with patch.object(Path, "home", return_value=Path("/Users/test")):
+            assert config.get_app_data_dir() == Path(
+                "/Users/test/Library/Application Support/RPAForge"
+            )
+
+    def test_linux_xdg_app_data_dir(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("RPAFORGE_DATA_DIR", raising=False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setenv("XDG_CONFIG_HOME", "/home/test/.config")
+        assert config.get_app_data_dir() == Path("/home/test/.config/rpaforge")
+
+
+class TestConfigRunsAndCheckpointsDir:
+    """Tests for runs and default checkpoint directory resolution."""
+
+    def test_runs_dir(self) -> None:
+        with patch.object(Path, "home", return_value=Path("/home/testuser")):
+            assert config.get_runs_dir() == Path("/home/testuser/.rpaforge/runs")
+
+    def test_default_checkpoint_dir(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("RPAFORGE_DATA_DIR", str(tmp_path))
+        assert config.get_default_checkpoint_dir() == tmp_path / "checkpoints"


### PR DESCRIPTION
Centralizes scattered environment variable access and platform data directory resolution in paforge-core. Introduces paforge.config with lazy path getters, updates caller modules (server.py, _worker_pool.py, unner.py, checkpoint.py, i18n.py), adds project namespacing for checkpoints, and includes unit tests.