### PR TITLE
refactor(core): core hygiene - remove duplicate validators, inline imports, add zh locale (fixes #696)

### DIFF
--- a/packages/core/src/rpaforge/bridge/handlers/debugger.py
+++ b/packages/core/src/rpaforge/bridge/handlers/debugger.py
@@ -164,13 +164,16 @@ def setup_debugger_handlers(cls: type) -> None:
 
         return {"callStack": stack}
 
-    cls._handle_set_breakpoint = _handle_set_breakpoint  # type: ignore[attr-defined]
-    cls._handle_remove_breakpoint = _handle_remove_breakpoint  # type: ignore[attr-defined]
-    cls._handle_toggle_breakpoint = _handle_toggle_breakpoint  # type: ignore[attr-defined]
-    cls._handle_get_breakpoints = _handle_get_breakpoints  # type: ignore[attr-defined]
-    cls._handle_step_over = _handle_step_over  # type: ignore[attr-defined]
-    cls._handle_step_into = _handle_step_into  # type: ignore[attr-defined]
-    cls._handle_step_out = _handle_step_out  # type: ignore[attr-defined]
-    cls._handle_continue = _handle_continue  # type: ignore[attr-defined]
-    cls._handle_get_variables = _handle_get_variables  # type: ignore[attr-defined]
-    cls._handle_get_call_stack = _handle_get_call_stack  # type: ignore[attr-defined]
+    for name, method in (
+        ("_handle_set_breakpoint", _handle_set_breakpoint),
+        ("_handle_remove_breakpoint", _handle_remove_breakpoint),
+        ("_handle_toggle_breakpoint", _handle_toggle_breakpoint),
+        ("_handle_get_breakpoints", _handle_get_breakpoints),
+        ("_handle_step_over", _handle_step_over),
+        ("_handle_step_into", _handle_step_into),
+        ("_handle_step_out", _handle_step_out),
+        ("_handle_continue", _handle_continue),
+        ("_handle_get_variables", _handle_get_variables),
+        ("_handle_get_call_stack", _handle_get_call_stack),
+    ):
+        setattr(cls, name, method)

--- a/packages/core/src/rpaforge/bridge/server.py
+++ b/packages/core/src/rpaforge/bridge/server.py
@@ -30,7 +30,7 @@ if sys.platform == "win32":
     if hasattr(sys.stdout, "reconfigure"):
         sys.stdout.reconfigure(encoding="utf-8", newline="")
 
-from rpaforge import config
+import rpaforge.config as config
 from rpaforge.bridge.handlers import BridgeHandlers
 from rpaforge.bridge.protocol import (
     JSONRPCError,

--- a/packages/core/src/rpaforge/codegen/python_generator.py
+++ b/packages/core/src/rpaforge/codegen/python_generator.py
@@ -78,21 +78,23 @@ def _sanitize_identifier_impl(name: str) -> str:
 
 
 def _validate_variable_name(name: str) -> None:
-    """Validate variable name against Python reserved keywords.
+    """Validate variable name against format limits and Python reserved keywords.
 
     Args:
         name: Variable name to validate
 
     Raises:
-        ValueError: If name is a Python reserved keyword or too long
+        ValueError: If name is a Python reserved keyword or format is invalid
     """
-    if len(name) > MAX_VARIABLE_NAME_LENGTH:
-        raise ValueError(
-            f"Variable name length ({len(name)}) exceeds maximum ({MAX_VARIABLE_NAME_LENGTH})"
-        )
+    try:
+        from rpaforge.core.validation import ValidationError, validate_variable_name
 
-    if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
-        raise ValueError(f"Invalid variable name format: {name}")
+        validate_variable_name(name, limit=MAX_VARIABLE_NAME_LENGTH)
+    except ValidationError as e:
+        msg = str(e)
+        if "exceeds maximum" in msg:
+            raise ValueError(msg) from None
+        raise ValueError(f"Invalid variable name format: {name}") from None
 
     if keyword.iskeyword(name):
         raise ValueError(f"Variable name '{name}' is a Python reserved keyword")

--- a/packages/core/src/rpaforge/core/_worker_pool.py
+++ b/packages/core/src/rpaforge/core/_worker_pool.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import psutil
 
-from rpaforge import config
+import rpaforge.config as config
 from rpaforge.i18n import _ as _t
 
 logger = logging.getLogger(__name__)

--- a/packages/core/src/rpaforge/core/checkpoint.py
+++ b/packages/core/src/rpaforge/core/checkpoint.py
@@ -17,7 +17,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from rpaforge import config
+import rpaforge.config as config
 from rpaforge.core.models import Breakpoint, CallFrame
 
 logger = logging.getLogger("rpaforge")

--- a/packages/core/src/rpaforge/core/diagram_converter.py
+++ b/packages/core/src/rpaforge/core/diagram_converter.py
@@ -11,6 +11,8 @@ import logging
 from typing import Any
 
 from rpaforge.core.execution import ActivityCall, Process, Task, TryCatchGroup
+from rpaforge.core.safe_evaluator import safe_eval
+from rpaforge.core.validation import validate_variable_name
 from rpaforge.core.validator import (
     ProcessValidator,
     ValidationResult,
@@ -95,7 +97,6 @@ class DiagramConverter:
     def _extract_variables(self, diagram: dict[str, Any]) -> dict[str, Any]:
         variables: dict[str, Any] = {}
         nodes = {n["id"]: n for n in diagram.get("nodes", []) if "id" in n}
-        from rpaforge.core.validation import validate_variable_name
 
         for variable in diagram.get("variables", []):
             if not isinstance(variable, dict):
@@ -116,8 +117,6 @@ class DiagramConverter:
                 var_name = block_data.get("variableName", "")
                 expr = block_data.get("expression", "")
                 if var_name:
-                    from rpaforge.core.validation import validate_variable_name
-
                     try:
                         validated_name = validate_variable_name(var_name)
                         try:
@@ -215,8 +214,6 @@ class DiagramConverter:
         stack: list[tuple[str, set[str], str | None]],
         visited: set[str],
     ) -> None:
-        from rpaforge.core.safe_evaluator import safe_eval
-
         successors = graph.get(node_id, [])
         true_target = next(
             (target for target, handle in successors if handle == "true"), None

--- a/packages/core/src/rpaforge/core/executor.py
+++ b/packages/core/src/rpaforge/core/executor.py
@@ -232,8 +232,6 @@ class ExecutionError(Exception):
         context: ExecutionContext | None = None,
     ) -> ExecutionError:
         """Create ExecutionError with full context from an exception."""
-        import datetime
-
         error_context = ErrorContext(
             message=str(exc),
             activity=activity,

--- a/packages/core/src/rpaforge/core/runner.py
+++ b/packages/core/src/rpaforge/core/runner.py
@@ -8,12 +8,15 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
+import uuid
 from collections.abc import Callable
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from rpaforge import config
+from rpaforge.config import get_runs_dir
 from rpaforge.core.audit import RunRecord, StepRecord
 from rpaforge.core.execution import (
     ActivityCall,
@@ -318,8 +321,6 @@ class ProcessRunner:
         self._current_depth = len(self._call_stack) + 1
 
         # Start tracking time for audit logging
-        import time
-
         self._step_start_time = time.time()
 
         frame = CallFrame(
@@ -356,8 +357,6 @@ class ProcessRunner:
             frame = self._call_stack.pop()
             # Record step completion for audit log.
             if self._step_start_time is not None:
-                import time
-
                 duration_ms = int((time.time() - self._step_start_time) * 1000)
                 node_id = frame.node_id or ""
                 result = result or {}
@@ -482,9 +481,6 @@ class ProcessRunner:
 
     def _init_audit_run(self, process: Process) -> None:
         """Initialize audit run record."""
-        import uuid
-        from datetime import datetime, timezone
-
         run_id = str(uuid.uuid4())
         now = datetime.now(timezone.utc).isoformat()
         self._current_run = RunRecord(
@@ -501,8 +497,6 @@ class ProcessRunner:
         if not self._current_run:
             return
 
-        from datetime import datetime, timezone
-
         now = datetime.now(timezone.utc).isoformat()
         self._current_run.finished_at = now
 
@@ -516,7 +510,7 @@ class ProcessRunner:
 
         # Save to disk
         try:
-            runs_dir = config.get_runs_dir()
+            runs_dir = get_runs_dir()
             self._last_audit_path = self._current_run.save(runs_dir)
             self._cleanup_old_runs(runs_dir, keep=50)
         except Exception as e:

--- a/packages/core/src/rpaforge/core/validation.py
+++ b/packages/core/src/rpaforge/core/validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -7,8 +8,6 @@ from typing import Any
 
 class ValidationError(Exception):
     """Raised when input validation fails."""
-
-    pass
 
 
 class LimitType(Enum):
@@ -116,8 +115,6 @@ def validate_variable_name(
         raise ValidationError(
             f"Variable name length ({len(name)}) exceeds maximum ({limit})"
         )
-
-    import re
 
     if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
         raise ValidationError(

--- a/packages/core/src/rpaforge/core/validator.py
+++ b/packages/core/src/rpaforge/core/validator.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from rpaforge.core.validation import ValidationError
 
-class ValidationError(Exception):
-    """Raised when input validation fails."""
-
-    pass
+__all__ = [
+    "ValidationError",
+    "ValidationErrorItem",
+    "ValidationResult",
+    "ProcessValidator",
+    "validate_diagram",
+    "validate_process",
+]
 
 
 class ValidationErrorItem:

--- a/packages/core/src/rpaforge/i18n.py
+++ b/packages/core/src/rpaforge/i18n.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any
 
-from rpaforge import config
+import rpaforge.config as config
 
 __all__ = ["_"]
 
@@ -65,7 +65,7 @@ def _(message: str, **kwargs: str | int | float) -> str:
     """
     # Determine language
     lang = config.get_lang()
-    if lang not in ("en", "ru", "de", "es"):
+    if lang not in ("en", "ru", "de", "es", "zh"):
         lang = "en"
 
     # Load translations

--- a/packages/core/tests/test_i18n.py
+++ b/packages/core/tests/test_i18n.py
@@ -1,0 +1,25 @@
+"""Tests for rpaforge.i18n module."""
+
+from __future__ import annotations
+
+import pytest
+
+from rpaforge.i18n import _
+
+
+class TestI18n:
+    """Tests for internationalization helper."""
+
+    def test_translate_fallback(self) -> None:
+        assert _("unknown.key") == "unknown.key"
+
+    def test_translate_supported_locales(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for lang in ("en", "ru", "de", "es", "zh"):
+            monkeypatch.setenv("LANG", lang)
+            assert isinstance(_("engine.runner_is_not_idle"), str)
+
+    def test_translate_unsupported_locale_defaults_to_en(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("LANG", "fr")
+        assert isinstance(_("engine.runner_is_not_idle"), str)


### PR DESCRIPTION
Cleans up core code hygiene across rpaforge-core: re-exports ValidationError from validation.py in validator.py, moves inline imports to module scope in runner.py/diagram_converter.py/executor.py/validation.py, refactors debugger handler registrations with setattr, adds zh locale support to i18n, and includes unit tests.