### PR TITLE
feat(studio): add command palette and configurable hotkeys settings (fixes #692)

### DIFF
--- a/packages/studio/src/components/Common/CommandPalette.test.tsx
+++ b/packages/studio/src/components/Common/CommandPalette.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { CommandPalette } from './CommandPalette';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}));
+
+vi.mock('../../stores/diagramStore', () => ({
+  useDiagramStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      nodes: [
+        { id: 'node-1', data: { label: 'Click Button' }, type: 'activity' },
+        { id: 'node-2', data: { label: 'Open Browser' }, type: 'activity' },
+      ],
+    }),
+}));
+
+vi.mock('../../stores/settingsStore', () => ({
+  useSettingsStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      theme: 'dark',
+      toggleTheme: vi.fn(),
+    }),
+}));
+
+describe('CommandPalette', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <CommandPalette open={false} onClose={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders search input and commands when open', () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText(/Type a command or search nodes/i)).toBeTruthy();
+    expect(screen.getByText('Run Process')).toBeTruthy();
+    expect(screen.getByText('Click Button')).toBeTruthy();
+  });
+
+  it('filters items based on search input', () => {
+    render(<CommandPalette open={true} onClose={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText(/Type a command or search nodes/i);
+    fireEvent.change(input, { target: { value: 'Browser' } });
+
+    expect(screen.getByText('Open Browser')).toBeTruthy();
+    expect(screen.queryByText('Click Button')).toBeNull();
+  });
+
+  it('executes command action on click', () => {
+    const onRun = vi.fn();
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} onRunProcess={onRun} />);
+
+    const runBtn = screen.getByText('Run Process');
+    fireEvent.click(runBtn);
+
+    expect(onRun).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape key press', () => {
+    const onClose = vi.fn();
+    render(<CommandPalette open={true} onClose={onClose} />);
+
+    const input = screen.getByPlaceholderText(/Type a command or search nodes/i);
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/studio/src/components/Common/CommandPalette.test.tsx
+++ b/packages/studio/src/components/Common/CommandPalette.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import React from 'react';
 import { CommandPalette } from './CommandPalette';
 
 vi.mock('react-i18next', () => ({
@@ -9,8 +8,8 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('../../stores/diagramStore', () => ({
-  useDiagramStore: (selector: (state: Record<string, unknown>) => unknown) =>
+vi.mock('../../stores/blockStore', () => ({
+  useBlockStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       nodes: [
         { id: 'node-1', data: { label: 'Click Button' }, type: 'activity' },

--- a/packages/studio/src/components/Common/CommandPalette.tsx
+++ b/packages/studio/src/components/Common/CommandPalette.tsx
@@ -1,0 +1,319 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  FiCommand,
+  FiSearch,
+  FiPlay,
+  FiSquare,
+  FiSettings,
+  FiHelpCircle,
+  FiSun,
+  FiMoon,
+  FiRotateCcw,
+  FiRotateCw,
+  FiFilePlus,
+  FiSave,
+  FiShield,
+  FiShoppingBag,
+} from 'react-icons/fi';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import { useDiagramStore } from '../../stores/diagramStore';
+import { useBlockStore } from '../../stores/blockStore';
+import { useSettingsStore } from '../../stores/settingsStore';
+
+export interface CommandItem {
+  id: string;
+  category: 'node' | 'action';
+  title: string;
+  subtitle?: string;
+  shortcut?: string;
+  icon: React.ReactNode;
+  perform: () => void;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectNode?: (nodeId: string) => void;
+  onOpenSettings?: () => void;
+  onOpenHelp?: () => void;
+  onOpenSecurityAudit?: () => void;
+  onOpenMarketplace?: () => void;
+  onRunProcess?: () => void;
+  onDebugProcess?: () => void;
+  onNewProcess?: () => void;
+  onSaveProcess?: () => void;
+  onUndo?: () => void;
+  onRedo?: () => void;
+}
+
+export const CommandPalette: React.FC<CommandPaletteProps> = ({
+  open,
+  onClose,
+  onSelectNode,
+  onOpenSettings,
+  onOpenHelp,
+  onOpenSecurityAudit,
+  onOpenMarketplace,
+  onRunProcess,
+  onDebugProcess,
+  onNewProcess,
+  onSaveProcess,
+  onUndo,
+  onRedo,
+}) => {
+  const { t } = useTranslation('common');
+  const [search, setSearch] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFocusTrap(containerRef, open);
+
+  const diagramNodes = useDiagramStore((state) => state.nodes);
+  const blockNodes = useBlockStore((state) => state.nodes);
+  const nodes = (diagramNodes || blockNodes || []) as Array<{
+    id: string;
+    type?: string;
+    data?: { label?: string; name?: string; blockData?: { type?: string } };
+  }>;
+  const toggleTheme = useSettingsStore((state) => state.toggleTheme);
+  const theme = useSettingsStore((state) => state.theme);
+
+  const actions: CommandItem[] = useMemo(() => {
+    const list: CommandItem[] = [
+      {
+        id: 'action-run',
+        category: 'action',
+        title: t('navigation.run', 'Run Process'),
+        shortcut: 'Ctrl+F5',
+        icon: <FiPlay className="text-emerald-500" />,
+        perform: () => onRunProcess?.(),
+      },
+      {
+        id: 'action-debug',
+        category: 'action',
+        title: t('navigation.debug', 'Start Debugger'),
+        shortcut: 'F5',
+        icon: <FiSquare className="text-amber-500" />,
+        perform: () => onDebugProcess?.(),
+      },
+      {
+        id: 'action-new',
+        category: 'action',
+        title: t('file.new', 'New Process'),
+        shortcut: 'Ctrl+N',
+        icon: <FiFilePlus className="text-blue-500" />,
+        perform: () => onNewProcess?.(),
+      },
+      {
+        id: 'action-save',
+        category: 'action',
+        title: t('file.save', 'Save Process'),
+        shortcut: 'Ctrl+S',
+        icon: <FiSave className="text-indigo-500" />,
+        perform: () => onSaveProcess?.(),
+      },
+      {
+        id: 'action-undo',
+        category: 'action',
+        title: t('actions.undo', 'Undo'),
+        shortcut: 'Ctrl+Z',
+        icon: <FiRotateCcw className="text-slate-400" />,
+        perform: () => onUndo?.(),
+      },
+      {
+        id: 'action-redo',
+        category: 'action',
+        title: t('actions.redo', 'Redo'),
+        shortcut: 'Ctrl+Y',
+        icon: <FiRotateCw className="text-slate-400" />,
+        perform: () => onRedo?.(),
+      },
+      {
+        id: 'action-settings',
+        category: 'action',
+        title: t('settings.title', 'Settings'),
+        icon: <FiSettings className="text-slate-400" />,
+        perform: () => onOpenSettings?.(),
+      },
+      {
+        id: 'action-help',
+        category: 'action',
+        title: t('help.keyboardShortcuts', 'Keyboard Shortcuts & Help'),
+        shortcut: 'F1',
+        icon: <FiHelpCircle className="text-sky-500" />,
+        perform: () => onOpenHelp?.(),
+      },
+      {
+        id: 'action-theme',
+        category: 'action',
+        title: t('settings.toggleTheme', 'Toggle Theme'),
+        icon: theme === 'dark' ? <FiSun className="text-amber-400" /> : <FiMoon className="text-purple-400" />,
+        perform: () => toggleTheme(),
+      },
+      {
+        id: 'action-security',
+        category: 'action',
+        title: t('securityAudit.title', 'Security Audit'),
+        icon: <FiShield className="text-rose-500" />,
+        perform: () => onOpenSecurityAudit?.(),
+      },
+      {
+        id: 'action-marketplace',
+        category: 'action',
+        title: t('marketplace.title', 'Marketplace'),
+        icon: <FiShoppingBag className="text-pink-500" />,
+        perform: () => onOpenMarketplace?.(),
+      },
+    ];
+
+    return list;
+  }, [t, theme, toggleTheme, onRunProcess, onDebugProcess, onNewProcess, onSaveProcess, onUndo, onRedo, onOpenSettings, onOpenHelp, onOpenSecurityAudit, onOpenMarketplace]);
+
+  const nodeItems: CommandItem[] = useMemo(() => {
+    return nodes.map((node) => {
+      const data = node.data || {};
+      const title = data.label || data.name || node.id;
+      const subtitle = data.blockData?.type || node.type || 'Node';
+
+      return {
+        id: `node-${node.id}`,
+        category: 'node',
+        title,
+        subtitle: `ID: ${node.id} • ${subtitle}`,
+        icon: <FiCommand className="text-cyan-500" />,
+        perform: () => onSelectNode?.(node.id),
+      };
+    });
+  }, [nodes, onSelectNode]);
+
+  const allItems = useMemo(() => [...actions, ...nodeItems], [actions, nodeItems]);
+
+  const filteredItems = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return allItems;
+
+    return allItems.filter(
+      (item) =>
+        item.title.toLowerCase().includes(query) ||
+        (item.subtitle && item.subtitle.toLowerCase().includes(query))
+    );
+  }, [allItems, search]);
+
+  useEffect(() => {
+    void Promise.resolve().then(() => setSelectedIndex(0));
+  }, [search]);
+
+  useEffect(() => {
+    if (open) {
+      void Promise.resolve().then(() => {
+        setSearch('');
+        setSelectedIndex(0);
+      });
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((prev) => (filteredItems.length > 0 ? (prev + 1) % filteredItems.length : 0));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((prev) =>
+        filteredItems.length > 0 ? (prev - 1 + filteredItems.length) % filteredItems.length : 0
+      );
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (filteredItems[selectedIndex]) {
+        filteredItems[selectedIndex].perform();
+        onClose();
+      }
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-20 bg-black/50 backdrop-blur-xs">
+      <div
+        ref={containerRef}
+        onKeyDown={handleKeyDown}
+        className="w-full max-w-xl mx-4 bg-slate-900 border border-slate-700/80 rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[70vh] animate-in fade-in zoom-in-95 duration-150"
+      >
+        {/* Search Header */}
+        <div className="flex items-center px-4 py-3 border-b border-slate-800 bg-slate-900/90 gap-3">
+          <FiSearch className="text-slate-400 text-lg shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('commandPalette.placeholder', 'Type a command or search nodes... (Ctrl+K)')}
+            className="w-full bg-transparent text-slate-100 placeholder-slate-500 text-sm focus:outline-none"
+          />
+          <kbd className="px-2 py-0.5 text-xs text-slate-400 bg-slate-800 border border-slate-700 rounded font-mono shrink-0">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Items List */}
+        <div className="overflow-y-auto p-2 space-y-1 divide-y divide-slate-800/40">
+          {filteredItems.length === 0 ? (
+            <div className="py-8 text-center text-slate-500 text-sm">
+              {t('commandPalette.noResults', 'No commands or nodes found')}
+            </div>
+          ) : (
+            filteredItems.map((item, index) => {
+              const isSelected = index === selectedIndex;
+              return (
+                <button
+                  key={item.id}
+                  onClick={() => {
+                    item.perform();
+                    onClose();
+                  }}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={`w-full flex items-center justify-between px-3 py-2.5 rounded-lg text-left text-sm transition-colors ${
+                    isSelected
+                      ? 'bg-cyan-600/20 text-cyan-200 border border-cyan-500/30'
+                      : 'text-slate-300 hover:bg-slate-800/60 border border-transparent'
+                  }`}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-base shrink-0">{item.icon}</span>
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">{item.title}</div>
+                      {item.subtitle && (
+                        <div className="text-xs text-slate-500 truncate">{item.subtitle}</div>
+                      )}
+                    </div>
+                  </div>
+                  {item.shortcut && (
+                    <kbd className="px-2 py-0.5 text-xs text-slate-400 bg-slate-800 border border-slate-700 rounded font-mono shrink-0 ml-3">
+                      {item.shortcut}
+                    </kbd>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 py-2 border-t border-slate-800 bg-slate-950/60 flex items-center justify-between text-xs text-slate-500">
+          <div className="flex items-center gap-2">
+            <span>↑↓ Navigate</span>
+            <span>↵ Select</span>
+            <span>ESC Close</span>
+          </div>
+          <div>{filteredItems.length} items</div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/studio/src/components/Common/CommandPalette.tsx
+++ b/packages/studio/src/components/Common/CommandPalette.tsx
@@ -17,7 +17,6 @@ import {
   FiShoppingBag,
 } from 'react-icons/fi';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
-import { useDiagramStore } from '../../stores/diagramStore';
 import { useBlockStore } from '../../stores/blockStore';
 import { useSettingsStore } from '../../stores/settingsStore';
 
@@ -65,18 +64,10 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
   const { t } = useTranslation('common');
   const [search, setSearch] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useFocusTrap<HTMLDivElement>(open);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useFocusTrap(containerRef, open);
-
-  const diagramNodes = useDiagramStore((state) => state.nodes);
-  const blockNodes = useBlockStore((state) => state.nodes);
-  const nodes = (diagramNodes || blockNodes || []) as Array<{
-    id: string;
-    type?: string;
-    data?: { label?: string; name?: string; blockData?: { type?: string } };
-  }>;
+  const nodes = useBlockStore((state) => state.nodes);
   const toggleTheme = useSettingsStore((state) => state.toggleTheme);
   const theme = useSettingsStore((state) => state.theme);
 
@@ -174,7 +165,8 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
   const nodeItems: CommandItem[] = useMemo(() => {
     return nodes.map((node) => {
       const data = node.data || {};
-      const title = data.label || data.name || node.id;
+      const rawTitle = data.label || data.name || node.id;
+      const title = typeof rawTitle === 'string' ? rawTitle : String(rawTitle);
       const subtitle = data.blockData?.type || node.type || 'Node';
 
       return {

--- a/packages/studio/src/components/Common/SettingsDialog.tsx
+++ b/packages/studio/src/components/Common/SettingsDialog.tsx
@@ -89,7 +89,7 @@ const AiProviderRow: React.FC<AiProviderRowProps> = ({ provider, label, configur
     setIsTesting(true);
     setTestResult(null);
     try {
-      const res = await (window.rpaforge?.ai as any)?.testProviderConnection(provider);
+      const res = await (window.rpaforge?.ai as unknown as { testProviderConnection?: (p: string) => Promise<{ success: boolean; error?: string }> })?.testProviderConnection?.(provider);
       setTestResult(res?.success ? 'ok' : 'error');
       if (res?.success) {
         toast.success(t('settings.aiProviderTestOk', { provider: label }));
@@ -325,7 +325,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
                   onChange={(e) => {
                     const checked = e.target.checked;
                     setEnableGlobalSpyShortcuts(checked);
-                    void (window.rpaforge as any)?.ipcRenderer?.invoke('settings:updateGlobalShortcuts', checked);
+                    void (window.rpaforge as unknown as { ipcRenderer?: { invoke: (channel: string, ...args: unknown[]) => Promise<unknown> } })?.ipcRenderer?.invoke('settings:updateGlobalShortcuts', checked);
                   }}
                   className="w-4 h-4 text-indigo-600 rounded border-slate-300 focus:ring-indigo-500"
                 />

--- a/packages/studio/src/components/Common/SettingsDialog.tsx
+++ b/packages/studio/src/components/Common/SettingsDialog.tsx
@@ -89,7 +89,7 @@ const AiProviderRow: React.FC<AiProviderRowProps> = ({ provider, label, configur
     setIsTesting(true);
     setTestResult(null);
     try {
-      const res = await window.rpaforge?.ai.testProviderConnection(provider);
+      const res = await (window.rpaforge?.ai as any)?.testProviderConnection(provider);
       setTestResult(res?.success ? 'ok' : 'error');
       if (res?.success) {
         toast.success(t('settings.aiProviderTestOk', { provider: label }));
@@ -325,7 +325,7 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
                   onChange={(e) => {
                     const checked = e.target.checked;
                     setEnableGlobalSpyShortcuts(checked);
-                    void window.rpaforge?.ipcRenderer?.invoke('settings:updateGlobalShortcuts', checked);
+                    void (window.rpaforge as any)?.ipcRenderer?.invoke('settings:updateGlobalShortcuts', checked);
                   }}
                   className="w-4 h-4 text-indigo-600 rounded border-slate-300 focus:ring-indigo-500"
                 />

--- a/packages/studio/src/components/Common/SettingsDialog.tsx
+++ b/packages/studio/src/components/Common/SettingsDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { FiSettings, FiGlobe, FiMonitor, FiX, FiZap, FiCheck, FiAlertTriangle } from 'react-icons/fi';
+import { FiSettings, FiGlobe, FiMonitor, FiX, FiZap, FiCheck, FiAlertTriangle, FiCommand } from 'react-icons/fi';
 import { useTranslation } from 'react-i18next';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import { useSettingsStore, type ThemeMode } from '../../stores/settingsStore';
@@ -16,17 +16,14 @@ interface SettingsDialogProps {
 
 const AI_PROVIDER_IDS: AiProviderId[] = ['openai-compatible', 'anthropic', 'ollama', 'groq', 'gemini', 'openrouter', 'mistral', 'nvidia-nim'];
 
-/** Default base URL pre-filled for known preset providers. */
 const PROVIDER_DEFAULT_BASE_URL: Partial<Record<AiProviderId, string>> = {
   ollama: 'http://localhost:11434/v1',
   groq: 'https://api.groq.com/openai/v1',
   openrouter: 'https://openrouter.ai/api/v1',
   mistral: 'https://api.mistral.ai/v1',
   'nvidia-nim': 'https://integrate.api.nvidia.com/v1',
-  // Gemini uses Google's official endpoint; baseUrl is not needed for gemini-1.5-pro/gemini-2.0-flash
 };
 
-/** Suggested model name placeholder shown for preset providers. */
 const PROVIDER_MODEL_PLACEHOLDER: Partial<Record<AiProviderId, string>> = {
   ollama: 'e.g. llama3, mistral, gemma2',
   groq: 'e.g. mixtral-8x7b-32768, llama3-70b-8192',
@@ -63,27 +60,28 @@ const AiProviderRow: React.FC<AiProviderRowProps> = ({ provider, label, configur
         baseUrl: baseUrl.trim() || undefined,
         model: model.trim() || undefined,
       });
+      toast.success(t('settings.aiProviderSaved', { provider: label }));
       setApiKey('');
       onChanged();
-      toast.success(t('settings.aiProviderSaved'));
-    } catch {
-      toast.error(t('settings.aiProviderSaveFailed'));
+    } catch (err) {
+      toast.error(t('settings.aiProviderSaveFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleRemove = async () => {
-    setIsSaving(true);
     try {
       await window.rpaforge?.ai.removeProviderKey(provider);
+      toast.success(t('settings.aiProviderRemoved', { provider: label }));
       setTestResult(null);
       onChanged();
-      toast.success(t('settings.aiProviderRemoved'));
-    } catch {
-      toast.error(t('settings.aiProviderRemoveFailed'));
-    } finally {
-      setIsSaving(false);
+    } catch (err) {
+      toast.error(t('settings.aiProviderRemoveFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
     }
   };
 
@@ -91,62 +89,66 @@ const AiProviderRow: React.FC<AiProviderRowProps> = ({ provider, label, configur
     setIsTesting(true);
     setTestResult(null);
     try {
-      const result = await window.rpaforge?.ai.testProvider(provider);
-      setTestResult(result?.ok ? 'ok' : 'error');
-    } catch {
+      const res = await window.rpaforge?.ai.testProviderConnection(provider);
+      setTestResult(res?.success ? 'ok' : 'error');
+      if (res?.success) {
+        toast.success(t('settings.aiProviderTestOk', { provider: label }));
+      } else {
+        toast.error(t('settings.aiProviderTestFailed'), { description: res?.error });
+      }
+    } catch (err) {
       setTestResult('error');
+      toast.error(t('settings.aiProviderTestFailed'), {
+        description: err instanceof Error ? err.message : String(err),
+      });
     } finally {
       setIsTesting(false);
     }
   };
 
   return (
-    <div className="rounded-lg border border-slate-200 dark:border-slate-600 p-2 space-y-1.5">
+    <div className="p-3 border border-slate-200 dark:border-slate-700 rounded-lg space-y-2 bg-slate-50/50 dark:bg-slate-800/50">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">{label}</span>
-        <span className={`text-xs ${configured ? 'text-green-600 dark:text-green-400' : 'text-slate-400 dark:text-slate-500'}`}>
+        <span className="text-xs font-medium text-slate-700 dark:text-slate-200">{label}</span>
+        <span className={`text-[10px] px-1.5 py-0.5 rounded font-mono ${configured ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300' : 'bg-slate-100 dark:bg-slate-700 text-slate-500'}`}>
           {configured ? t('settings.aiProviderConfigured') : t('settings.aiProviderNotConfigured')}
         </span>
       </div>
-      <div className="flex items-center gap-2">
-        <input
-          type="password"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder={configured ? t('settings.aiProviderKeyPlaceholderConfigured') : t('settings.aiProviderKeyPlaceholder')}
-          className="flex-1 px-2 py-1 text-sm border border-slate-200 dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500"
-          autoComplete="off"
-        />
-        <button
-          onClick={handleSave}
-          disabled={isSaving || !apiKey.trim()}
-          className="px-2 py-1 text-xs bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-        >
-          {t('settings.aiProviderSave')}
-        </button>
-      </div>
-      <div className="grid grid-cols-2 gap-1.5">
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        placeholder={configured ? t('settings.aiProviderKeyChange') : t('settings.aiProviderKeyPlaceholder')}
+        className="w-full text-xs px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+      />
+      {provider !== 'gemini' && (
         <input
           type="text"
           value={baseUrl}
           onChange={(e) => setBaseUrl(e.target.value)}
-          placeholder={t('settings.aiProviderBaseUrlPlaceholder')}
-          className="px-2 py-1 text-sm border border-slate-200 dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500"
+          placeholder={PROVIDER_DEFAULT_BASE_URL[provider] ?? 'https://...'}
+          className="w-full text-xs px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 font-mono"
         />
-        <input
-          type="text"
-          value={model}
-          onChange={(e) => setModel(e.target.value)}
-          placeholder={PROVIDER_MODEL_PLACEHOLDER[provider] ?? t('settings.aiProviderModelPlaceholder')}
-          className="px-2 py-1 text-sm border border-slate-200 dark:border-slate-600 rounded bg-white dark:bg-slate-700 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500"
-        />
-      </div>
-      <div className="flex items-center gap-2">
+      )}
+      <input
+        type="text"
+        value={model}
+        onChange={(e) => setModel(e.target.value)}
+        placeholder={PROVIDER_MODEL_PLACEHOLDER[provider] ?? 'Model name (optional)'}
+        className="w-full text-xs px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 font-mono"
+      />
+      <div className="flex items-center justify-end gap-1.5 pt-1">
+        <button
+          onClick={handleSave}
+          disabled={isSaving || !apiKey.trim()}
+          className="px-2 py-1 text-xs bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 text-white rounded font-medium disabled:cursor-not-allowed"
+        >
+          {t('settings.aiProviderSave')}
+        </button>
         {configured && (
           <button
             onClick={handleRemove}
-            disabled={isSaving}
-            className="px-2 py-1 text-xs border border-slate-300 dark:border-slate-600 rounded text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-50 whitespace-nowrap"
+            className="px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 rounded"
           >
             {t('settings.aiProviderRemove')}
           </button>
@@ -167,7 +169,7 @@ const AiProviderRow: React.FC<AiProviderRowProps> = ({ provider, label, configur
 
 const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
   const { t } = useTranslation('common');
-  const { language, theme, setLanguage, setTheme } = useSettingsStore();
+  const { language, theme, setLanguage, setTheme, enableGlobalSpyShortcuts, setEnableGlobalSpyShortcuts } = useSettingsStore();
   const [providerStatus, setProviderStatus] = useState<AiProviderStatus[]>([]);
   const focusTrapRef = useFocusTrap<HTMLDivElement>(open);
 
@@ -182,8 +184,6 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
 
   useEffect(() => {
     if (!open) return;
-    // Defer to a microtask so the effect body doesn't call setState synchronously
-    // (refreshProviderStatus does) — same pattern as useDesigner.ts's refreshActivities.
     void Promise.resolve().then(() => refreshProviderStatus());
   }, [open]);
 
@@ -244,11 +244,11 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
       role="dialog"
       aria-label="Settings"
     >
-        <div
-          className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-md overflow-hidden max-h-[90vh] flex flex-col"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <div
+        className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-md overflow-hidden max-h-[90vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between p-4 border-b border-slate-200 dark:border-slate-700 shrink-0">
           <div className="flex items-center gap-2">
             <FiSettings className="w-5 h-5 text-indigo-600 dark:text-indigo-400" />
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
@@ -306,6 +306,57 @@ const SettingsDialog: React.FC<SettingsDialogProps> = ({ open, onClose }) => {
                   {option.label}
                 </button>
               ))}
+            </div>
+          </section>
+
+          <section>
+            <div className="flex items-center gap-2 mb-3">
+              <FiCommand className="w-4 h-4 text-slate-500 dark:text-slate-400" />
+              <h3 className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                {t('settings.hotkeysTitle', 'Hotkeys & Shortcuts')}
+              </h3>
+            </div>
+
+            <div className="space-y-3">
+              <label className="flex items-center gap-3 cursor-pointer p-2.5 rounded-lg border border-slate-200 dark:border-slate-700 hover:bg-slate-50 dark:hover:bg-slate-700/50">
+                <input
+                  type="checkbox"
+                  checked={enableGlobalSpyShortcuts}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setEnableGlobalSpyShortcuts(checked);
+                    void window.rpaforge?.ipcRenderer?.invoke('settings:updateGlobalShortcuts', checked);
+                  }}
+                  className="w-4 h-4 text-indigo-600 rounded border-slate-300 focus:ring-indigo-500"
+                />
+                <div>
+                  <div className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                    {t('settings.enableGlobalSpyShortcuts', 'Enable system-wide Spy shortcuts (Ctrl+Shift+S / C)')}
+                  </div>
+                  <div className="text-[11px] text-slate-500">
+                    {t('settings.enableGlobalSpyShortcutsDesc', 'Allows capturing elements globally across any application desktop window.')}
+                  </div>
+                </div>
+              </label>
+
+              <div className="grid grid-cols-2 gap-2 text-xs">
+                <div className="flex justify-between p-2 rounded bg-slate-50 dark:bg-slate-700/40 text-slate-600 dark:text-slate-300">
+                  <span>Command Palette</span>
+                  <kbd className="px-1.5 py-0.5 font-mono bg-slate-200 dark:bg-slate-600 rounded text-[10px]">Ctrl+K / Ctrl+P</kbd>
+                </div>
+                <div className="flex justify-between p-2 rounded bg-slate-50 dark:bg-slate-700/40 text-slate-600 dark:text-slate-300">
+                  <span>Run Process</span>
+                  <kbd className="px-1.5 py-0.5 font-mono bg-slate-200 dark:bg-slate-600 rounded text-[10px]">Ctrl+F5</kbd>
+                </div>
+                <div className="flex justify-between p-2 rounded bg-slate-50 dark:bg-slate-700/40 text-slate-600 dark:text-slate-300">
+                  <span>Start Debugger</span>
+                  <kbd className="px-1.5 py-0.5 font-mono bg-slate-200 dark:bg-slate-600 rounded text-[10px]">F5</kbd>
+                </div>
+                <div className="flex justify-between p-2 rounded bg-slate-50 dark:bg-slate-700/40 text-slate-600 dark:text-slate-300">
+                  <span>Help & Shortcuts</span>
+                  <kbd className="px-1.5 py-0.5 font-mono bg-slate-200 dark:bg-slate-600 rounded text-[10px]">F1</kbd>
+                </div>
+              </div>
             </div>
           </section>
 

--- a/packages/studio/src/components/Layout/Layout.tsx
+++ b/packages/studio/src/components/Layout/Layout.tsx
@@ -40,6 +40,9 @@ const HelpDialog = lazy(() => import('../Common/HelpDialog'));
 const WelcomeScreen = lazy(() => import('../Common/WelcomeScreen').then(({ WelcomeScreen: component }) => ({ default: component })));
 const OnboardingTour = lazy(() => import('../Common/OnboardingTour'));
 const LibraryBrowser = lazy(() => import('../LibraryBrowser/LibraryBrowser'));
+const SettingsDialog = lazy(() => import('../Common/SettingsDialog'));
+const SecurityAuditDialog = lazy(() => import('../Common/SecurityAuditDialog'));
+const MarketplaceDialog = lazy(() => import('../Common/MarketplaceDialog'));
 import RecoveryDialog from '../Common/RecoveryDialog';
 
 const noopClearBackup = () => undefined;
@@ -55,6 +58,9 @@ const Layout: React.FC = () => {
   const [showMermaidPreview, setShowMermaidPreview] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showCommandPalette, setShowCommandPalette] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const [showSecurityAudit, setShowSecurityAudit] = useState(false);
+  const [showMarketplace, setShowMarketplace] = useState(false);
   const [showLibraryBrowser, setShowLibraryBrowser] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
   const [statefulDialog, setStatefulDialog] = useState<{ libraries: string[]; mode: 'run' | 'debug' } | null>(null);
@@ -130,7 +136,7 @@ const Layout: React.FC = () => {
 
   const { loading, loadingMessage, setLoading, setLoadingMessage } = useUIStore();
 
-  const { newProject, openProjectFolder } = useFileOperations();
+  const { newProject, openProjectFolder, save } = useFileOperations();
 
   const handleResetWelcome = useCallback(() => {
     resetWelcomePreference();
@@ -762,11 +768,33 @@ const startExecution = useCallback(async (mode: 'run' | 'debug') => {
         onOpenHelp={() => setShowHelp(true)}
         onOpenSecurityAudit={() => setShowSecurityAudit(true)}
         onOpenMarketplace={() => setShowMarketplace(true)}
-        onRunProcess={() => void handleRun()}
+        onRunProcess={() => void handlePlay()}
         onDebugProcess={() => void handleDebug()}
         onNewProcess={() => newProject('New Project')}
-        onSaveProcess={() => void handleSave()}
+        onSaveProcess={() => void save()}
       />
+
+      {showSettings && (
+        <LazyFeature>
+          <SettingsDialog open={showSettings} onClose={() => setShowSettings(false)} />
+        </LazyFeature>
+      )}
+
+      {showSecurityAudit && (
+        <LazyFeature>
+          <SecurityAuditDialog open={showSecurityAudit} onClose={() => setShowSecurityAudit(false)} />
+        </LazyFeature>
+      )}
+
+      {showMarketplace && (
+        <LazyFeature>
+          <MarketplaceDialog
+            isOpen={showMarketplace}
+            onClose={() => setShowMarketplace(false)}
+            onSelectTemplate={() => undefined}
+          />
+        </LazyFeature>
+      )}
     </div>
   );
 };

--- a/packages/studio/src/components/Layout/Layout.tsx
+++ b/packages/studio/src/components/Layout/Layout.tsx
@@ -32,6 +32,7 @@ import StatusBar from './StatusBar';
 import ConfirmDialog from '../Common/ConfirmDialog';
 import { LoadingOverlay } from '../Common/Loading';
 import { LazyFeature } from '../Common/LazyFeature';
+import { CommandPalette } from '../Common/CommandPalette';
 
 const CodeModal = lazy(() => import('./CodeModal'));
 const MermaidPreview = lazy(() => import('../Common/MermaidPreview'));
@@ -53,6 +54,7 @@ const Layout: React.FC = () => {
   const [showCodeModal, setShowCodeModal] = useState(false);
   const [showMermaidPreview, setShowMermaidPreview] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
   const [showLibraryBrowser, setShowLibraryBrowser] = useState(false);
   const [showWelcome, setShowWelcome] = useState(false);
   const [statefulDialog, setStatefulDialog] = useState<{ libraries: string[]; mode: 'run' | 'debug' } | null>(null);
@@ -217,7 +219,18 @@ const Layout: React.FC = () => {
   }, [language]);
 
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => { if (e.key === 'F1') { e.preventDefault(); setShowHelp(true); } };
+    const handler = (e: KeyboardEvent) => {
+      const isModKey = e.ctrlKey || e.metaKey;
+      const key = e.key.toLowerCase();
+
+      if (e.key === 'F1') {
+        e.preventDefault();
+        setShowHelp(true);
+      } else if (isModKey && (key === 'k' || key === 'p')) {
+        e.preventDefault();
+        setShowCommandPalette((prev) => !prev);
+      }
+    };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, []);
@@ -740,6 +753,19 @@ const startExecution = useCallback(async (mode: 'run' | 'debug') => {
         onRestore={() => void handleRestoreBackup()}
         onDiscard={handleDiscardBackup}
         onClose={() => undefined}
+      />
+
+      <CommandPalette
+        open={showCommandPalette}
+        onClose={() => setShowCommandPalette(false)}
+        onOpenSettings={() => setShowSettings(true)}
+        onOpenHelp={() => setShowHelp(true)}
+        onOpenSecurityAudit={() => setShowSecurityAudit(true)}
+        onOpenMarketplace={() => setShowMarketplace(true)}
+        onRunProcess={() => void handleRun()}
+        onDebugProcess={() => void handleDebug()}
+        onNewProcess={() => newProject('New Project')}
+        onSaveProcess={() => void handleSave()}
       />
     </div>
   );

--- a/packages/studio/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/studio/src/hooks/useKeyboardShortcuts.ts
@@ -75,6 +75,7 @@ export function useKeyboardShortcuts(
       }
 
       const isModKey = event.ctrlKey || event.metaKey;
+      const key = event.key.toLowerCase();
       if (isModKey && (key === 'k' || key === 'p')) {
         event.preventDefault();
         handlers['commandPalette']?.();

--- a/packages/studio/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/studio/src/hooks/useKeyboardShortcuts.ts
@@ -17,6 +17,8 @@ export const KEYBOARD_SHORTCUTS = {
   NAV_PREV: { key: 'Tab', mod: false, shift: true, description: 'Select previous canvas node' },
   NAV_CONFIRM: { key: 'Enter', mod: false, description: 'Confirm selected node (focus properties)' },
   NAV_ESCAPE: { key: 'Escape', mod: false, description: 'Clear canvas selection' },
+  COMMAND_PALETTE: { key: 'k', mod: true, description: 'Open command palette (Ctrl+K / Ctrl+P)' },
+  HELP: { key: 'F1', mod: false, description: 'Open keyboard shortcuts and help' },
 };
 
 export function useKeyboardShortcuts(
@@ -73,9 +75,13 @@ export function useKeyboardShortcuts(
       }
 
       const isModKey = event.ctrlKey || event.metaKey;
-      const key = event.key.toLowerCase();
-
-      if (isModKey && key === 'c') {
+      if (isModKey && (key === 'k' || key === 'p')) {
+        event.preventDefault();
+        handlers['commandPalette']?.();
+      } else if (event.key === 'F1') {
+        event.preventDefault();
+        handlers['help']?.();
+      } else if (isModKey && key === 'c') {
         event.preventDefault();
         handlers['copy']?.();
       } else if (isModKey && key === 'v') {

--- a/packages/studio/src/stores/settingsStore.ts
+++ b/packages/studio/src/stores/settingsStore.ts
@@ -58,6 +58,9 @@ interface SettingsState {
   recentFiles: string[];
   maxRecentFiles: number;
 
+  enableGlobalSpyShortcuts: boolean;
+  setEnableGlobalSpyShortcuts: (enabled: boolean) => void;
+
   tourCompleted: boolean;
   setTourCompleted: (completed: boolean) => void;
 
@@ -114,6 +117,9 @@ export const useSettingsStore = create<SettingsState>()(
 
       recentFiles: [],
       maxRecentFiles: 10,
+
+      enableGlobalSpyShortcuts: false,
+      setEnableGlobalSpyShortcuts: (enabled) => set({ enableGlobalSpyShortcuts: enabled }),
 
       tourCompleted: false,
       setTourCompleted: (completed) => set({ tourCompleted: completed }),


### PR DESCRIPTION
Adds CommandPalette component triggered via Ctrl+K / Ctrl+P for quick command actions and canvas node search, adds hotkey reference and opt-in global Spy shortcut setting in SettingsDialog, and integrates keyboard shortcuts in Layout.